### PR TITLE
Removes guava dependency

### DIFF
--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/ApacheRequestAdapter.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/ApacheRequestAdapter.java
@@ -7,7 +7,6 @@ import org.apache.http.HttpRequest;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.client.ClientRequestAdapter;
-import com.google.common.base.Optional;
 
 class ApacheRequestAdapter implements ClientRequestAdapter {
 
@@ -28,13 +27,9 @@ class ApacheRequestAdapter implements ClientRequestAdapter {
     }
 
     @Override
-    public Optional<String> getSpanName() {
-        Optional<String> spanName = Optional.absent();
+    public String getSpanName() {
         final Header spanNameHeader = request.getFirstHeader(BraveHttpHeaders.SpanName.getName());
-        if (spanNameHeader != null) {
-            spanName = Optional.fromNullable(spanNameHeader.getValue());
-        }
-        return spanName;
+        return spanNameHeader != null ? spanNameHeader.getValue() : null;
     }
 
     @Override

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
@@ -8,7 +8,6 @@ import org.apache.http.protocol.HttpContext;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import com.google.common.base.Optional;
 
 /**
  * Apache HttpClient {@link HttpRequestInterceptor} that adds brave/zipkin annotations to outgoing client request.
@@ -25,44 +24,31 @@ import com.google.common.base.Optional;
 public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
 
     private final ClientRequestInterceptor clientRequestInterceptor;
-    private final Optional<String> serviceName;
+    private final String serviceName;
 
     /**
      * Creates a new instance.
      *
      * @param clientTracer ClientTracer should not be <code>null</code>.
-     * @param serviceName Optional Service Name override
-     * @param spanNameFilter
+     * @param serviceName Nullable Service Name override
+     * @param spanNameFilter Nullable {@link SpanNameFilter}
      */
-    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, final Optional<String> serviceName,
+    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, final String serviceName,
         final SpanNameFilter spanNameFilter) {
-        this(clientTracer, serviceName, Optional.of(spanNameFilter));
-    }
-
-    /**
-     * Creates a new instance.
-     *
-     * @param clientTracer ClientTracer should not be <code>null</code>.
-     * @param serviceName Optional Service Name override
-     */
-    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, final Optional<String> serviceName) {
-        this(clientTracer, serviceName, Optional.<SpanNameFilter>absent());
-
-    }
-
-    /**
-     * Private constructor, creates a new instance.
-     *
-     * @param clientTracer ClientTracer should not be <code>null</code>.
-     * @param serviceName Optional Service Name override
-     * @param spanNameFilter optional {@link SpanNameFilter}
-     */
-    private BraveHttpRequestInterceptor(final ClientTracer clientTracer, final Optional<String> serviceName,
-        final Optional<SpanNameFilter> spanNameFilter) {
         Validate.notNull(clientTracer);
-        Validate.notNull(serviceName);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         this.serviceName = serviceName;
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param clientTracer ClientTracer should not be <code>null</code>.
+     * @param serviceName Nullable Service Name override
+     */
+    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, final String serviceName) {
+        this(clientTracer, serviceName, null);
+
     }
 
     /**

--- a/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/test/java/com/github/kristofa/brave/httpclient/ITBraveHttpRequestAndResponseInterceptor.java
@@ -9,7 +9,6 @@ import com.github.kristofa.test.http.HttpResponseImpl;
 import com.github.kristofa.test.http.Method;
 import com.github.kristofa.test.http.MockHttpServer;
 import com.github.kristofa.test.http.UnsatisfiedExpectationException;
-import com.google.common.base.Optional;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -77,7 +76,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, Optional.<String>absent()))
+            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, null))
                 .addInterceptorFirst(new BraveHttpResponseInterceptor(clientTracer)).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST);
@@ -112,7 +111,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, Optional.<String>absent()))
+            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, null))
                 .addInterceptorFirst(new BraveHttpResponseInterceptor(clientTracer)).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST);
@@ -150,7 +149,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, Optional.<String>absent()))
+            HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, null))
                 .addInterceptorFirst(new BraveHttpResponseInterceptor(clientTracer)).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST_WITH_QUERY_PARAMS);
@@ -188,7 +187,7 @@ public class ITBraveHttpRequestAndResponseInterceptor {
         responseProvider.set(request, response);
 
         final CloseableHttpClient httpclient =
-                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, Optional.of(SERVICE)))
+                HttpClients.custom().addInterceptorFirst(new BraveHttpRequestInterceptor(clientTracer, SERVICE))
                         .addInterceptorFirst(new BraveHttpResponseInterceptor(clientTracer)).build();
         try {
             final HttpGet httpGet = new HttpGet(REQUEST);

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestAdapter.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestAdapter.java
@@ -1,7 +1,5 @@
 package com.github.kristofa.brave.client;
 
-import com.google.common.base.Optional;
-
 import java.net.URI;
 
 /**
@@ -28,10 +26,10 @@ public interface ClientRequestAdapter {
     /**
      * Get optional span name.
      *
-     * @return Optional span name. In case span name is not provided ClientRequestInterceptor will
+     * @return nullable span name. In case span name is not provided ClientRequestInterceptor will
      * use a default way to build span name.
      */
-    Optional<String> getSpanName();
+    String getSpanName();
 
     /**
      * ClientRequestInterceptor will submit http headers using this method

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
@@ -5,7 +5,6 @@ import org.apache.commons.lang.Validate;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import com.google.common.base.Optional;
 
 /**
  * Intercepts a client request and takes care of tracing the request. It will decide if we need to trace current request and
@@ -24,9 +23,9 @@ public class ClientRequestInterceptor {
 
     private final ClientTracer clientTracer;
     private static final String REQUEST_ANNOTATION = "request";
-    private final Optional<SpanNameFilter> spanNameFilter;
+    private final SpanNameFilter spanNameFilter;
 
-    public ClientRequestInterceptor(final ClientTracer clientTracer, final Optional<SpanNameFilter> spanNameFilter) {
+    public ClientRequestInterceptor(final ClientTracer clientTracer, final SpanNameFilter spanNameFilter) {
         Validate.notNull(clientTracer);
         this.clientTracer = clientTracer;
         this.spanNameFilter = spanNameFilter;
@@ -36,27 +35,26 @@ public class ClientRequestInterceptor {
      * Handles a client request.
      *
      * @param clientRequestAdapter Provides context about the request.
-     * @param serviceNameOverride Optional name of the service the client request calls. In case it is not specified the name
+     * @param serviceNameOverride Nullable name of the service the client request calls. In case it is not specified the name
      *            will be derived from the URI of the request. It is important the used service name should be same on client
      *            as on server side.
      */
-    public void handle(final ClientRequestAdapter clientRequestAdapter, final Optional<String> serviceNameOverride) {
+    public void handle(final ClientRequestAdapter clientRequestAdapter, final String serviceNameOverride) {
         final String spanName = getSpanName(clientRequestAdapter, serviceNameOverride);
         final SpanId newSpanId = clientTracer.startNewSpan(spanName);
         ClientRequestHeaders.addTracingHeaders(clientRequestAdapter, newSpanId, spanName);
-        final Optional<String> serviceName = getServiceName(clientRequestAdapter, serviceNameOverride);
-        if (serviceName.isPresent()) {
-            clientTracer.setCurrentClientServiceName(serviceName.get());
+        final String serviceName = getServiceName(clientRequestAdapter, serviceNameOverride);
+        if (serviceName != null) {
+            clientTracer.setCurrentClientServiceName(serviceName);
         }
         clientTracer.submitBinaryAnnotation(REQUEST_ANNOTATION, clientRequestAdapter.getMethod() + " "
             + clientRequestAdapter.getUri());
         clientTracer.setClientSent();
     }
 
-    private Optional<String> getServiceName(final ClientRequestAdapter clientRequestAdapter,
-        final Optional<String> serviceNameOverride) {
-        Optional<String> serviceName;
-        if (serviceNameOverride.isPresent()) {
+    private String getServiceName(final ClientRequestAdapter clientRequestAdapter, final String serviceNameOverride) {
+        String serviceName = null;
+        if (serviceNameOverride != null) {
             serviceName = serviceNameOverride;
         } else {
             final String path = clientRequestAdapter.getUri().getPath();
@@ -64,21 +62,19 @@ public class ClientRequestInterceptor {
             if (split.length > 2 && path.startsWith("/")) {
                 // If path starts with '/', then context is between first two '/'. Left over is path for service.
                 final int contextPathSeparatorIndex = path.indexOf("/", 1);
-                serviceName = Optional.of(path.substring(1, contextPathSeparatorIndex));
-            } else {
-                serviceName = Optional.absent();
+                serviceName = path.substring(1, contextPathSeparatorIndex);
             }
         }
         return serviceName;
     }
 
-    private String getSpanName(final ClientRequestAdapter clientRequestAdapter, final Optional<String> serviceNameOverride) {
+    private String getSpanName(final ClientRequestAdapter clientRequestAdapter, final String serviceNameOverride) {
         String spanName;
-        final Optional<String> spanNameFromRequest = clientRequestAdapter.getSpanName();
+        final String spanNameFromRequest = clientRequestAdapter.getSpanName();
         final String path = clientRequestAdapter.getUri().getPath();
-        if (spanNameFromRequest.isPresent()) {
-            return spanNameFromRequest.get();
-        } else if (serviceNameOverride.isPresent()) {
+        if (spanNameFromRequest != null) {
+            return spanNameFromRequest;
+        } else if (serviceNameOverride != null) {
             spanName = path;
         } else {
             final String[] split = path.split("/");
@@ -90,8 +86,8 @@ public class ClientRequestInterceptor {
                 spanName = path;
             }
         }
-        if (spanNameFilter.isPresent()) {
-            spanName = spanNameFilter.get().filterSpanName(spanName);
+        if (spanNameFilter != null) {
+            spanName = spanNameFilter.filterSpanName(spanName);
         }
         return spanName;
     }

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImpl.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImpl.java
@@ -1,8 +1,6 @@
 package com.github.kristofa.brave.client.spanfilter;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -11,7 +9,6 @@ import java.util.regex.Pattern;
  * this filter will only allow these span names to be set as the client span name (else "[span name not defined]").
  */
 public class PatternBasedSpanNameFilterImpl implements SpanNameFilter {
-    @VisibleForTesting
     static final String DEFAULT_SPAN_NAME = "[span name not defined]";
 
     private final Iterable<SpanNamePattern> spanNamePatterns;
@@ -22,7 +19,7 @@ public class PatternBasedSpanNameFilterImpl implements SpanNameFilter {
     }
 
     public PatternBasedSpanNameFilterImpl(Iterable<String> spanNamePatterns, String defaultSpanName) {
-        final List<SpanNamePattern> patternNamePairs = Lists.newArrayList();
+        final List<SpanNamePattern> patternNamePairs = new ArrayList<>();
         if (spanNamePatterns != null) {
             for (String spanNamePattern : spanNamePatterns) {
                 if (spanNamePattern != null) {

--- a/brave-client/src/test/java/com/github/kristofa/brave/client/ClientRequestInterceptorTest.java
+++ b/brave-client/src/test/java/com/github/kristofa/brave/client/ClientRequestInterceptorTest.java
@@ -19,7 +19,6 @@ import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import com.google.common.base.Optional;
 
 public class ClientRequestInterceptorTest {
 
@@ -42,24 +41,23 @@ public class ClientRequestInterceptorTest {
     public void setUp() throws Exception {
         mockClientTracer = mock(ClientTracer.class);
         mockSpanNameFilter = mock(SpanNameFilter.class);
-        final Optional<SpanNameFilter> optionalSpanNameFilter = Optional.absent();
-        interceptor = new ClientRequestInterceptor(mockClientTracer, optionalSpanNameFilter);
+        interceptor = new ClientRequestInterceptor(mockClientTracer, null);
         clientRequestAdapter = mock(ClientRequestAdapter.class);
         when(clientRequestAdapter.getUri()).thenReturn(URI.create(FULL_PATH));
         when(clientRequestAdapter.getMethod()).thenReturn(METHOD);
-        when(clientRequestAdapter.getSpanName()).thenReturn(Optional.<String>absent());
+        when(clientRequestAdapter.getSpanName()).thenReturn(null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testBraveHttpRequestInterceptor() {
-        new ClientRequestInterceptor(null, Optional.of(mockSpanNameFilter));
+        new ClientRequestInterceptor(null, mockSpanNameFilter);
     }
 
     @Test
     public void testProcessNoTracing() throws HttpException, IOException {
         when(mockClientTracer.startNewSpan(PATH)).thenReturn(null);
 
-        interceptor.handle(clientRequestAdapter, Optional.<String>absent());
+        interceptor.handle(clientRequestAdapter, null);
 
         final InOrder inOrder = inOrder(mockClientTracer, clientRequestAdapter);
 
@@ -79,7 +77,7 @@ public class ClientRequestInterceptorTest {
         when(spanId.getTraceId()).thenReturn(TRACE_ID);
         when(mockClientTracer.startNewSpan(PATH)).thenReturn(spanId);
 
-        interceptor.handle(clientRequestAdapter, Optional.<String>absent());
+        interceptor.handle(clientRequestAdapter, null);
 
         final InOrder inOrder = inOrder(mockClientTracer, clientRequestAdapter);
 
@@ -104,7 +102,7 @@ public class ClientRequestInterceptorTest {
         when(spanId.getTraceId()).thenReturn(TRACE_ID);
         when(mockClientTracer.startNewSpan(PATH)).thenReturn(spanId);
 
-        interceptor.handle(clientRequestAdapter, Optional.<String>absent());
+        interceptor.handle(clientRequestAdapter, null);
 
         final InOrder inOrder = inOrder(mockClientTracer, clientRequestAdapter);
 
@@ -128,7 +126,7 @@ public class ClientRequestInterceptorTest {
         when(spanId.getTraceId()).thenReturn(TRACE_ID);
         when(mockClientTracer.startNewSpan(FULL_PATH)).thenReturn(spanId);
 
-        interceptor.handle(clientRequestAdapter, Optional.of(SERVICE_NAME));
+        interceptor.handle(clientRequestAdapter, SERVICE_NAME);
 
         final InOrder inOrder = inOrder(mockClientTracer, clientRequestAdapter);
 
@@ -154,8 +152,8 @@ public class ClientRequestInterceptorTest {
         when(mockClientTracer.startNewSpan(FILTERED_PATH)).thenReturn(spanId);
         when(mockSpanNameFilter.filterSpanName(PATH)).thenReturn(FILTERED_PATH);
 
-        interceptor = new ClientRequestInterceptor(mockClientTracer, Optional.of(mockSpanNameFilter));
-        interceptor.handle(clientRequestAdapter, Optional.<String>absent());
+        interceptor = new ClientRequestInterceptor(mockClientTracer, mockSpanNameFilter);
+        interceptor.handle(clientRequestAdapter, null);
 
         final InOrder inOrder = inOrder(mockClientTracer, clientRequestAdapter, mockSpanNameFilter);
         inOrder.verify(mockSpanNameFilter).filterSpanName(PATH);

--- a/brave-client/src/test/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImplTest.java
+++ b/brave-client/src/test/java/com/github/kristofa/brave/client/spanfilter/PatternBasedSpanNameFilterImplTest.java
@@ -1,8 +1,8 @@
 package com.github.kristofa.brave.client.spanfilter;
 
-import com.google.common.collect.Lists;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.*;
@@ -15,7 +15,7 @@ public class PatternBasedSpanNameFilterImplTest {
         final String remove = "/api/{something}/{else}/remove";
         final String anythingElse = "/api/{anythingelse}";
         final PatternBasedSpanNameFilterImpl filter
-                = new PatternBasedSpanNameFilterImpl(Lists.newArrayList(add, remove, anythingElse));
+                = new PatternBasedSpanNameFilterImpl(Arrays.asList(add, remove, anythingElse));
 
         assertEquals(add, filter.filterSpanName("/api/clients/relationships/add"));
         assertEquals(remove, filter.filterSpanName("/api/science/math/remove"));
@@ -26,7 +26,7 @@ public class PatternBasedSpanNameFilterImplTest {
     public void testNoMatch() throws Exception {
         final String add = "/api/{something}/{else}/add";
         final PatternBasedSpanNameFilterImpl filter
-                = new PatternBasedSpanNameFilterImpl(Lists.newArrayList(add));
+                = new PatternBasedSpanNameFilterImpl(Arrays.asList(add));
 
         assertEquals(PatternBasedSpanNameFilterImpl.DEFAULT_SPAN_NAME, filter.filterSpanName("/api/nomatch"));
     }
@@ -48,7 +48,8 @@ public class PatternBasedSpanNameFilterImplTest {
     @Test
     public void testHandlesNullPatterns() throws Exception {
         final String undef = "not-defined";
-        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Lists.<String>newArrayList(null, null), undef);
+        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Arrays.asList(
+            null, null), undef);
 
         assertEquals(undef, filter.filterSpanName("/api/not-a-match"));
     }
@@ -56,7 +57,8 @@ public class PatternBasedSpanNameFilterImplTest {
     @Test
     public void testCaseInsensitive() throws Exception {
         final String updatePattern = "/api/{userid}/update";
-        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Lists.newArrayList(updatePattern));
+        final PatternBasedSpanNameFilterImpl filter = new PatternBasedSpanNameFilterImpl(Arrays.asList(
+            updatePattern));
 
         assertEquals(updatePattern, filter.filterSpanName("/api/12/update"));
         assertEquals(updatePattern, filter.filterSpanName("/api/12/UPDATE"));

--- a/brave-impl/pom.xml
+++ b/brave-impl/pom.xml
@@ -37,10 +37,6 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.1</version>
     </dependency>
-    <dependency>
-    	<groupId>com.google.guava</groupId>
-    	<artifactId>guava</artifactId>
-    </dependency>
   </dependencies>
   
   <build>	

--- a/brave-impl/src/main/java/com/github/kristofa/brave/IdConversion.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/IdConversion.java
@@ -1,7 +1,5 @@
 package com.github.kristofa.brave;
 
-import com.google.common.primitives.UnsignedLongs;
-
 /**
  * Contains conversion utilities for converting trace and span ids from long to string and vice
  * versa.
@@ -28,9 +26,8 @@ public class IdConversion {
 	 * @param id trace, span or parent span id.
 	 * @return String representation.
 	 */
-	public static String convertToString(final long id)
-	{
-		return UnsignedLongs.toString(id, 16);
+	public static String convertToString(final long id) {
+            return Long.toHexString(id);
 	}
 	
 	/**
@@ -39,9 +36,27 @@ public class IdConversion {
 	 * @param id trace, span or parent span id.
 	 * @return Long representation.
 	 */
-	public static long convertToLong(final String id)
-	{
-		return UnsignedLongs.parseUnsignedLong(id, 16);
+	public static long convertToLong(final String id) {
+	  if (id.length() == 0 || id.length() > 16) {
+	    throw new NumberFormatException(
+		id + " should be a <=16 character lower-hex string with no prefix");
+	  }
+
+	  long result = 0;
+
+	  for (char c : id.toCharArray()) {
+	    result <<= 4;
+
+	    if (c >= '0' && c <= '9') {
+	      result |= c - '0';
+	    } else if (c >= 'a' && c <= 'f') {
+	      result |= c - 'a' + 10;
+	    } else {
+	      throw new NumberFormatException("character " + c + " not lower hex in " + id);
+	    }
+	  }
+
+	  return result;
 	}
 
 }

--- a/brave-impl/src/test/java/com/github/kristofa/brave/IdConversionTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/IdConversionTest.java
@@ -52,4 +52,23 @@ public class IdConversionTest {
 		assertEquals(longId, IdConversion.convertToLong(expectedId));
 	}
 
+	@Test(expected = NumberFormatException.class)
+	public void testIdTooLong() {
+	        IdConversion.convertToLong("7ffffffffffffffff");
+	}
+
+        @Test(expected = NumberFormatException.class)
+        public void testIdEmpty() {
+                IdConversion.convertToLong("");
+        }
+
+	@Test(expected = NumberFormatException.class)
+	public void testIdShouldntHavePrefix() {
+		IdConversion.convertToLong("0x7fffffffffffffff");
+	}
+
+	@Test(expected = NumberFormatException.class)
+	public void testIdShouldntBeUppercase() {
+	  	IdConversion.convertToLong("7FFFFFFFFFFFFFFF");
+	}
 }

--- a/brave-interfaces/pom.xml
+++ b/brave-interfaces/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-  
+
   <dependencies>
     <dependency>
         <groupId>org.apache.thrift</groupId>
@@ -41,11 +41,6 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
    </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-      </dependency>
-
   </dependencies>
   
   <build>

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
@@ -3,7 +3,6 @@ package com.github.kristofa.brave.jaxrs2;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import com.google.common.base.Optional;
 import org.apache.commons.lang.Validate;
 
 import javax.inject.Inject;
@@ -20,17 +19,15 @@ import java.io.IOException;
 public class BraveClientRequestFilter implements ClientRequestFilter {
 
     private final ClientRequestInterceptor clientRequestInterceptor;
-    private final Optional<String> serviceName;
+    private final String serviceName;
 
     @Inject
-    public BraveClientRequestFilter(final ClientTracer clientTracer, final Optional<String> serviceName) {
-        this(clientTracer, serviceName, Optional.<SpanNameFilter>absent());
+    public BraveClientRequestFilter(final ClientTracer clientTracer, final String serviceName) {
+        this(clientTracer, serviceName, null);
     }
 
-    public BraveClientRequestFilter(final ClientTracer clientTracer, final Optional<String> serviceName, final Optional<SpanNameFilter> spanNameFilter) {
+    public BraveClientRequestFilter(final ClientTracer clientTracer, final String serviceName, final SpanNameFilter spanNameFilter) {
         Validate.notNull(clientTracer);
-        Validate.notNull(serviceName);
-        Validate.notNull(spanNameFilter);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         this.serviceName = serviceName;
     }

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
@@ -2,7 +2,6 @@ package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientResponseInterceptor;
-import com.google.common.base.Optional;
 import org.apache.commons.lang.Validate;
 
 import javax.inject.Inject;
@@ -21,9 +20,8 @@ public class BraveClientResponseFilter implements ClientResponseFilter {
     private final ClientResponseInterceptor clientResponseInterceptor;
 
     @Inject
-    public BraveClientResponseFilter(final ClientTracer clientTracer, final Optional<String> serviceName) {
+    public BraveClientResponseFilter(final ClientTracer clientTracer, final String serviceName) {
         Validate.notNull(clientTracer);
-        Validate.notNull(serviceName);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
     }
 

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/JaxRS2ClientRequestAdapter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/JaxRS2ClientRequestAdapter.java
@@ -2,7 +2,6 @@ package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.client.ClientRequestAdapter;
-import com.google.common.base.Optional;
 
 import javax.ws.rs.client.ClientRequestContext;
 import java.net.URI;
@@ -26,13 +25,9 @@ public class JaxRS2ClientRequestAdapter implements ClientRequestAdapter {
     }
 
     @Override
-    public Optional<String> getSpanName() {
-        Optional<String> spanName = Optional.absent();
+    public String getSpanName() {
         final Object spanNameHeader = clientRequest.getHeaders().getFirst(BraveHttpHeaders.SpanName.getName());
-        if (spanNameHeader != null) {
-            spanName = Optional.fromNullable(spanNameHeader.toString());
-        }
-        return spanName;
+        return spanNameHeader != null ? spanNameHeader.toString() : null;
     }
 
     @Override

--- a/brave-jaxrs2/src/test/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilterTest.java
+++ b/brave-jaxrs2/src/test/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilterTest.java
@@ -2,7 +2,6 @@ package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.ClientTracer;
-import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +43,7 @@ public class BraveClientRequestFilterTest {
         uri = new URI("/test-uri");
         when(clientRequestContext.getUri()).thenReturn(uri);
 
-        braveClientRequestFilter = new BraveClientRequestFilter(clientTracer, Optional.<String>absent());
+        braveClientRequestFilter = new BraveClientRequestFilter(clientTracer, null);
 
     }
 

--- a/brave-jaxrs2/src/test/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilterTest.java
+++ b/brave-jaxrs2/src/test/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilterTest.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.ClientTracer;
-import com.google.common.base.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +27,7 @@ public class BraveClientResponseFilterTest {
 
     @Before
     public void setUp() throws Exception {
-        braveClientResponseFilter = new BraveClientResponseFilter(clientTracer, Optional.<String>absent());
+        braveClientResponseFilter = new BraveClientResponseFilter(clientTracer, null);
     }
 
     @Test

--- a/brave-jaxrs2/src/test/java/com/github/kristofa/brave/jaxrs2/JaxRS2ClientRequestAdapterTest.java
+++ b/brave-jaxrs2/src/test/java/com/github/kristofa/brave/jaxrs2/JaxRS2ClientRequestAdapterTest.java
@@ -1,8 +1,6 @@
 package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
-import com.google.common.base.Optional;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -65,7 +63,7 @@ public class JaxRS2ClientRequestAdapterTest {
 
     @Test
     public void testGetSpanName() throws Exception {
-        assertThat(jaxRS2ClientRequestAdapter.getSpanName(), is(Optional.of(TEST_SPAN_NAME)));
+        assertThat(jaxRS2ClientRequestAdapter.getSpanName(), is(TEST_SPAN_NAME));
 
         verify(request).getHeaders();
         verify(headers).getFirst(BraveHttpHeaders.SpanName.getName());

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientRequestAdapter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientRequestAdapter.java
@@ -4,7 +4,6 @@ import java.net.URI;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.client.ClientRequestAdapter;
-import com.google.common.base.Optional;
 import com.sun.jersey.api.client.ClientRequest;
 
 class JerseyClientRequestAdapter implements ClientRequestAdapter {
@@ -26,13 +25,9 @@ class JerseyClientRequestAdapter implements ClientRequestAdapter {
     }
 
     @Override
-    public Optional<String> getSpanName() {
-        Optional<String> spanName = Optional.absent();
+    public String getSpanName() {
         final Object spanNameHeader = clientRequest.getHeaders().getFirst(BraveHttpHeaders.SpanName.getName());
-        if (spanNameHeader != null) {
-            spanName = Optional.fromNullable(spanNameHeader.toString());
-        }
-        return spanName;
+        return spanNameHeader != null ? spanNameHeader.toString() : null;
     }
 
     @Override

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
@@ -9,7 +9,6 @@ import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;
 import com.github.kristofa.brave.client.ClientResponseInterceptor;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import com.google.common.base.Optional;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
@@ -24,17 +23,15 @@ public class JerseyClientTraceFilter extends ClientFilter {
 
     private final ClientRequestInterceptor clientRequestInterceptor;
     private final ClientResponseInterceptor clientResponseInterceptor;
-    private final Optional<String> serviceName;
+    private final String serviceName;
 
     @Inject
-    public JerseyClientTraceFilter(final ClientTracer clientTracer, final Optional<String> serviceName) {
-        this(clientTracer, serviceName, Optional.<SpanNameFilter>absent());
+    public JerseyClientTraceFilter(final ClientTracer clientTracer, final String serviceName) {
+        this(clientTracer, serviceName, null);
     }
 
-    public JerseyClientTraceFilter(final ClientTracer clientTracer, final Optional<String> serviceName, final Optional<SpanNameFilter> spanNameFilter) {
+    public JerseyClientTraceFilter(final ClientTracer clientTracer, final String serviceName, final SpanNameFilter spanNameFilter) {
         Validate.notNull(clientTracer);
-        Validate.notNull(serviceName);
-        Validate.notNull(spanNameFilter);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
         this.serviceName = serviceName;

--- a/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ClientServletCompatibilityTest.java
+++ b/brave-jersey/src/test/java/com/github/kristofa/brave/jersey/ClientServletCompatibilityTest.java
@@ -26,7 +26,6 @@ import com.github.kristofa.brave.EndPointSubmitter;
 import com.github.kristofa.brave.ServerTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.client.ClientRequestHeaders;
-import com.google.common.base.Optional;
 import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.core.util.StringKeyObjectValueIgnoreCaseMultivaluedMap;
 
@@ -53,7 +52,7 @@ public class ClientServletCompatibilityTest {
 
     @Before
     public void setUp() {
-        clientFilter = new JerseyClientTraceFilter(clientTracer, Optional.<String>absent());
+        clientFilter = new JerseyClientTraceFilter(clientTracer, null);
         servletFilter = new ServletTraceFilter(serverTracer, endPointSubmitter);
     }
 

--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveJersey2.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/ITBraveJersey2.java
@@ -5,7 +5,6 @@ import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.EndPointSubmitter;
 import com.github.kristofa.brave.jaxrs2.BraveClientRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveClientResponseFilter;
-import com.google.common.base.Optional;
 import com.twitter.zipkin.gen.Span;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
@@ -33,8 +32,8 @@ public class ITBraveJersey2 extends JerseyTest {
     @Test
     public void testBraveJersey2() {
         WebTarget target = target("/brave-jersey2/test");
-        target.register(new BraveClientRequestFilter(clientTracer, Optional.<String>absent()));
-        target.register(new BraveClientResponseFilter(clientTracer, Optional.<String>absent()));
+        target.register(new BraveClientRequestFilter(clientTracer, null));
+        target.register(new BraveClientResponseFilter(clientTracer, null));
 
         final EndPointSubmitter endPointSubmitter = Brave.getEndPointSubmitter();
         endPointSubmitter.submit("127.0.0.1", 9998, "brave-jersey2");

--- a/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBean.java
+++ b/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBean.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave.mysql;
 
 import com.github.kristofa.brave.ClientTracer;
-import com.google.common.base.Optional;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -12,11 +11,11 @@ import java.io.IOException;
 public class MySQLStatementInterceptorManagementBean implements Closeable {
 
     public MySQLStatementInterceptorManagementBean(final ClientTracer tracer) {
-        MySQLStatementInterceptor.setClientTracer(Optional.of(tracer));
+        MySQLStatementInterceptor.setClientTracer(tracer);
     }
 
     @Override
     public void close() throws IOException {
-        MySQLStatementInterceptor.setClientTracer(Optional.<ClientTracer>absent());
+        MySQLStatementInterceptor.setClientTracer(null);
     }
 }

--- a/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBeanTest.java
+++ b/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBeanTest.java
@@ -1,14 +1,13 @@
 package com.github.kristofa.brave.mysql;
 
 import com.github.kristofa.brave.ClientTracer;
-import com.google.common.base.Optional;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 
@@ -23,13 +22,13 @@ public class MySQLStatementInterceptorManagementBeanTest {
 
     @After
     public void clearStatementInterceptor() {
-        MySQLStatementInterceptor.setClientTracer(Optional.<ClientTracer>absent());
+        MySQLStatementInterceptor.setClientTracer(null);
     }
 
     @Test
     public void afterPropertiesSetShouldSetTracerOnStatementInterceptor() {
         new MySQLStatementInterceptorManagementBean(clientTracer);
-        assertSame(clientTracer, MySQLStatementInterceptor.clientTracer.get());
+        assertSame(clientTracer, MySQLStatementInterceptor.clientTracer);
     }
 
     @Test
@@ -37,11 +36,11 @@ public class MySQLStatementInterceptorManagementBeanTest {
 
         final MySQLStatementInterceptorManagementBean subject = new MySQLStatementInterceptorManagementBean(clientTracer);
 
-        MySQLStatementInterceptor.setClientTracer(Optional.of(clientTracer));
+        MySQLStatementInterceptor.setClientTracer(clientTracer);
 
         subject.close();
 
-        assertEquals(Optional.<ClientTracer>absent(), MySQLStatementInterceptor.clientTracer);
+        assertNull(MySQLStatementInterceptor.clientTracer);
     }
 
 }

--- a/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorTest.java
+++ b/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorTest.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave.mysql;
 
 import com.github.kristofa.brave.ClientTracer;
-import com.google.common.base.Optional;
 import com.mysql.jdbc.Connection;
 import com.mysql.jdbc.PreparedStatement;
 import com.mysql.jdbc.ResultSetInternalMethods;
@@ -30,12 +29,12 @@ public class MySQLStatementInterceptorTest {
     public void setUp() throws Exception {
         subject = new MySQLStatementInterceptor();
         clientTracer = mock(ClientTracer.class);
-        MySQLStatementInterceptor.setClientTracer(Optional.of(clientTracer));
+        MySQLStatementInterceptor.setClientTracer(clientTracer);
     }
 
     @Test
     public void preProcessShouldNotFailIfNoClientTracer() throws Exception {
-        MySQLStatementInterceptor.setClientTracer(Optional.<ClientTracer>absent());
+        MySQLStatementInterceptor.setClientTracer(null);
 
         assertNull(subject.preProcess("sql", mock(Statement.class), mock(Connection.class)));
 
@@ -84,7 +83,7 @@ public class MySQLStatementInterceptorTest {
 
     @Test
     public void postProcessShouldNotFailIfNoClientTracer() throws Exception {
-        MySQLStatementInterceptor.setClientTracer(Optional.<ClientTracer>absent());
+        MySQLStatementInterceptor.setClientTracer(null);
 
         assertNull(subject.postProcess("sql", mock(Statement.class), mock(ResultSetInternalMethods.class), mock(Connection.class), 1, true, true, null));
 

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
@@ -15,7 +15,6 @@ import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;
 import com.github.kristofa.brave.client.ClientResponseInterceptor;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import com.google.common.base.Optional;
 
 /**
  * {@link ClientExecutionInterceptor} that uses the {@link ClientTracer} to set up a new span. </p> It adds the necessary
@@ -54,28 +53,18 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
      */
     @Autowired(required = false)
     public BraveClientExecutionInterceptor(final ClientTracer clientTracer) {
-        this(clientTracer, Optional.<SpanNameFilter>absent());
+        this(clientTracer, null);
     }
 
     /**
      * Create a new instance.
      *
      * @param clientTracer ClientTracer.
+     * @param spanNameFilter Nullable {@link SpanNameFilter}
      */
     @Autowired(required = false)
     public BraveClientExecutionInterceptor(final ClientTracer clientTracer, final SpanNameFilter spanNameFilter) {
-        this(clientTracer, Optional.of(spanNameFilter));
-    }
-
-    /**
-     * Private Constructor.
-     *
-     * @param clientTracer ClientTracer
-     * @param spanNameFilter {@link Optional} {@link SpanNameFilter}
-     */
-    private BraveClientExecutionInterceptor(final ClientTracer clientTracer, final Optional<SpanNameFilter> spanNameFilter) {
         Validate.notNull(clientTracer);
-        Validate.notNull(spanNameFilter);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
     }
@@ -88,7 +77,7 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
 
         final ClientRequest request = ctx.getRequest();
 
-        clientRequestInterceptor.handle(new RestEasyClientRequestAdapter(request), Optional.<String>absent());
+        clientRequestInterceptor.handle(new RestEasyClientRequestAdapter(request), null);
 
         ClientResponse<?> response = null;
         Exception exception = null;

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/RestEasyClientRequestAdapter.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/RestEasyClientRequestAdapter.java
@@ -6,8 +6,6 @@ import org.jboss.resteasy.client.ClientRequest;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.client.ClientRequestAdapter;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 
 class RestEasyClientRequestAdapter implements ClientRequestAdapter {
 
@@ -21,8 +19,10 @@ class RestEasyClientRequestAdapter implements ClientRequestAdapter {
     public URI getUri() {
         try {
             return URI.create(clientRequest.getUri());
+        } catch (final RuntimeException e) {
+            throw e;
         } catch (final Exception e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -32,13 +32,9 @@ class RestEasyClientRequestAdapter implements ClientRequestAdapter {
     }
 
     @Override
-    public Optional<String> getSpanName() {
-        Optional<String> spanName = Optional.absent();
+    public String getSpanName() {
         final Object spanNameHeader = clientRequest.getHeaders().getFirst(BraveHttpHeaders.SpanName.getName());
-        if (spanNameHeader != null) {
-            spanName = Optional.fromNullable(spanNameHeader.toString());
-        }
-        return spanName;
+        return spanNameHeader != null ? spanNameHeader.toString() : null;
     }
 
     @Override

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveResteasy.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/ITBraveResteasy.java
@@ -5,7 +5,6 @@ import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.EndPointSubmitter;
 import com.github.kristofa.brave.jaxrs2.BraveClientRequestFilter;
 import com.github.kristofa.brave.jaxrs2.BraveClientResponseFilter;
-import com.google.common.base.Optional;
 import com.twitter.zipkin.gen.Span;
 import org.apache.http.client.ClientProtocolException;
 import org.eclipse.jetty.server.Connector;
@@ -79,8 +78,8 @@ public class ITBraveResteasy {
         ClientTracer clientTracer = appContext.getBean(ClientTracer.class);
         final BraveRestEasyResource client =
                 new ResteasyClientBuilder().build().target("http://localhost:8080/BraveRestEasyIntegration")
-                        .register(new BraveClientRequestFilter(clientTracer, Optional.<String>absent()))
-                        .register(new BraveClientResponseFilter(clientTracer, Optional.<String>absent()))
+                        .register(new BraveClientRequestFilter(clientTracer, null))
+                        .register(new BraveClientResponseFilter(clientTracer, null))
                         .proxy(BraveRestEasyResource.class);
 
         @SuppressWarnings("unchecked")

--- a/brave-tracefilters/pom.xml
+++ b/brave-tracefilters/pom.xml
@@ -36,10 +36,6 @@
         <artifactId>curator-framework</artifactId>
         <version>2.2.0-incubating</version>  
     </dependency>
-      <dependency>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-      </dependency>
     <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,6 @@
 		        <artifactId>httpcore</artifactId>
 		        <version>4.3.2</version>
     		</dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>14.0.1</version>
-        </dependency>
   	</dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Guava leads to library conflicts and interoperability problems. By
removing the guava dep, we can more safely be placed in core libraries.

Instead of forcing users to use or convert out of Guava's optional, we
now use nullable. Nullable is trivial to convert to an optional type in
the caller's favorite functional library or language.