### PR TITLE
Reverts main code to Java 7; Adds animal-sniffer to verify

### DIFF
--- a/brave-impl/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -1,8 +1,6 @@
 package com.github.kristofa.brave;
 
-
 import java.util.Collection;
-import java.util.Optional;
 
 public interface ClientRequestAdapter {
 
@@ -17,10 +15,10 @@ public interface ClientRequestAdapter {
      * Enrich the request with the Spanid so we pass the state to the
      * service we are calling.
      *
-     * @param spanId Optional span id. If empty we don't need to trace request and you
+     * @param spanId Nullable span id. If empty we don't need to trace request and you
      *               should pass an indication along with the request that indicates we won't trace this request.
      */
-    void addSpanIdToRequest(Optional<SpanId> spanId);
+    void addSpanIdToRequest(SpanId spanId);
 
     /**
      * Returns the service name for request. The service name is expected to be the same

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ClientRequestInterceptor.java
@@ -1,8 +1,5 @@
 package com.github.kristofa.brave;
 
-
-import java.util.Optional;
-
 /**
  * Contains logic for handling an outgoing client request.
  */
@@ -24,9 +21,9 @@ public class ClientRequestInterceptor {
         SpanId spanId = clientTracer.startNewSpan(adapter.getSpanName());
         if (spanId == null) {
             // We will not trace this request.
-            adapter.addSpanIdToRequest(Optional.empty());
+            adapter.addSpanIdToRequest(null);
         } else {
-            adapter.addSpanIdToRequest(Optional.of(spanId));
+            adapter.addSpanIdToRequest(spanId);
             clientTracer.setCurrentClientServiceName(adapter.getClientServiceName());
             for(KeyValueAnnotation annotation : adapter.requestAnnotations()) {
                 clientTracer.submitBinaryAnnotation(annotation.getKey(), annotation.getValue());

--- a/brave-impl/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/ClientRequestInterceptorTest.java
@@ -7,7 +7,6 @@ import org.mockito.InOrder;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
@@ -36,7 +35,7 @@ public class ClientRequestInterceptorTest {
         InOrder inOrder = inOrder(clientTracer, adapter);
         inOrder.verify(adapter).getSpanName();
         inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
-        inOrder.verify(adapter).addSpanIdToRequest(Optional.empty());
+        inOrder.verify(adapter).addSpanIdToRequest(null);
         verifyNoMoreInteractions(clientTracer, adapter);
     }
 
@@ -52,7 +51,7 @@ public class ClientRequestInterceptorTest {
         InOrder inOrder = inOrder(clientTracer, adapter);
         inOrder.verify(adapter).getSpanName();
         inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
-        inOrder.verify(adapter).addSpanIdToRequest(Optional.of(spanId));
+        inOrder.verify(adapter).addSpanIdToRequest(spanId);
         inOrder.verify(adapter).getClientServiceName();
         inOrder.verify(clientTracer).setCurrentClientServiceName(SERVICE_NAME);
         inOrder.verify(adapter).requestAnnotations();
@@ -73,7 +72,7 @@ public class ClientRequestInterceptorTest {
         InOrder inOrder = inOrder(clientTracer, adapter);
         inOrder.verify(adapter).getSpanName();
         inOrder.verify(clientTracer).startNewSpan(SPAN_NAME);
-        inOrder.verify(adapter).addSpanIdToRequest(Optional.of(spanId));
+        inOrder.verify(adapter).addSpanIdToRequest(spanId);
         inOrder.verify(adapter).getClientServiceName();
         inOrder.verify(clientTracer).setCurrentClientServiceName(SERVICE_NAME);
         inOrder.verify(adapter).requestAnnotations();

--- a/pom.xml
+++ b/pom.xml
@@ -167,16 +167,49 @@
       	  <plugins>
        	     	<plugin>
                 	<inherited>true</inherited>
-                	<groupId>org.apache.maven.plugins</groupId>
                 	<artifactId>maven-compiler-plugin</artifactId>
-                	<version>2.5.1</version>
+                	<version>3.1</version>
                 	<configuration>
                    		<source>1.8</source>
                     	<target>1.8</target>
                     	<optimize>true</optimize>
                     	<debug>true</debug>
                 	</configuration>
+                    <executions>
+                        <!-- Ensure main source tree compiles to Java 7 bytecode. -->
+                        <execution>
+                            <id>default-compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <source>1.7</source>
+                                <target>1.7</target>
+                            </configuration>
+                        </execution>
+                    </executions>
        	     	</plugin>
+                <!-- Make sure Java 8 classes and methods aren't accidentally used -->
+                <plugin>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>1.14</version>
+                    <configuration>
+                        <signature>
+                            <groupId>org.codehaus.mojo.signature</groupId>
+                            <artifactId>java17</artifactId>
+                            <version>1.0</version>
+                        </signature>
+                    </configuration>
+                </plugin>
             	<plugin>
                 	<groupId>org.apache.maven.plugins</groupId>
                 	<artifactId>maven-eclipse-plugin</artifactId>


### PR DESCRIPTION
Java 8 bytecode is supported in many runtimes, and is a reasonable path
for us to take. However, mandating it for all code will limit adoption.

Few who use non-java languages or alternate functional libraries will be
able to leverage java 8 Optional for some time, and it will be more of a
chore to them than nullable. Scala 2.10, other JVM languages and
functional libraries do not support Java 8 bytecode. Even when options
are available, many apps haven't moved their dependency graphs over.
Finally, some CI processes do not run on JDK 8, yet.

For the sake of adoption, it seems best to at least temporarily decouple
our main source tree from requiring Java 8. Otherwise, we'd need another
branch, just for Java 7, or accept some users can't use brave 3 until
their dependency tree, CI processes and deployment are ready for Java 8.

This constrains the main source tree to Java 7 using maven compiler
configuration. It also verifies Java 8 libraries aren't in use in main
code via animal-sniffer. Using maven or animal-sniffer overrides, we can
allow source (such as server code) to use Java 8, while still being
cautious about shared library code.