### PR TITLE
Completes migration off Java 8; Consolidates use of commons-lang3

### DIFF
--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -24,6 +24,15 @@
   </properties>
   <dependencies>
     <dependency>
+       <!-- For @javax.annotation.Nullable -->
+       <groupId>com.google.code.findbugs</groupId>
+       <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.3.3</version>
@@ -33,11 +42,6 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
         <version>4.3.2</version>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.1</version>
     </dependency>
     <dependency>
         <groupId>com.github.kristofa</groupId>
@@ -75,9 +79,12 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>      
-        </plugin>        
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
-        
   </build>
 </project>

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
@@ -1,6 +1,6 @@
 package com.github.kristofa.brave.httpclient;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
@@ -8,6 +8,8 @@ import org.apache.http.protocol.HttpContext;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
+
+import javax.annotation.Nullable;
 
 /**
  * Apache HttpClient {@link HttpRequestInterceptor} that adds brave/zipkin annotations to outgoing client request.
@@ -33,8 +35,8 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
      * @param serviceName Nullable Service Name override
      * @param spanNameFilter Nullable {@link SpanNameFilter}
      */
-    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, final String serviceName,
-        final SpanNameFilter spanNameFilter) {
+    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, @Nullable final String serviceName,
+        @Nullable final SpanNameFilter spanNameFilter) {
         Validate.notNull(clientTracer);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         this.serviceName = serviceName;
@@ -46,9 +48,8 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
      * @param clientTracer ClientTracer should not be <code>null</code>.
      * @param serviceName Nullable Service Name override
      */
-    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, final String serviceName) {
+    public BraveHttpRequestInterceptor(final ClientTracer clientTracer, @Nullable final String serviceName) {
         this(clientTracer, serviceName, null);
-
     }
 
     /**

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave.httpclient;
 
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientResponseInterceptor;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;

--- a/brave-client/pom.xml
+++ b/brave-client/pom.xml
@@ -27,6 +27,11 @@
 
     <dependencies>
         <dependency>
+            <!-- For @javax.annotation.Nullable -->
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.kristofa</groupId>
             <artifactId>brave-impl</artifactId>
             <version>3.0.0-beta-1-SNAPSHOT</version>
@@ -59,8 +64,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
@@ -1,10 +1,12 @@
 package com.github.kristofa.brave.client;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
+
+import javax.annotation.Nullable;
 
 /**
  * Intercepts a client request and takes care of tracing the request. It will decide if we need to trace current request and
@@ -39,7 +41,7 @@ public class ClientRequestInterceptor {
      *            will be derived from the URI of the request. It is important the used service name should be same on client
      *            as on server side.
      */
-    public void handle(final ClientRequestAdapter clientRequestAdapter, final String serviceNameOverride) {
+    public void handle(final ClientRequestAdapter clientRequestAdapter, @Nullable final String serviceNameOverride) {
         final String spanName = getSpanName(clientRequestAdapter, serviceNameOverride);
         final SpanId newSpanId = clientTracer.startNewSpan(spanName);
         ClientRequestHeaders.addTracingHeaders(clientRequestAdapter, newSpanId, spanName);

--- a/brave-client/src/main/java/com/github/kristofa/brave/client/ClientResponseInterceptor.java
+++ b/brave-client/src/main/java/com/github/kristofa/brave/client/ClientResponseInterceptor.java
@@ -1,6 +1,6 @@
 package com.github.kristofa.brave.client;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import com.github.kristofa.brave.ClientTracer;
 

--- a/brave-client/src/test/java/com/github/kristofa/brave/client/ClientRequestInterceptorTest.java
+++ b/brave-client/src/test/java/com/github/kristofa/brave/client/ClientRequestInterceptorTest.java
@@ -48,7 +48,7 @@ public class ClientRequestInterceptorTest {
         when(clientRequestAdapter.getSpanName()).thenReturn(null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testBraveHttpRequestInterceptor() {
         new ClientRequestInterceptor(null, mockSpanNameFilter);
     }

--- a/brave-client/src/test/java/com/github/kristofa/brave/client/ClientResponseInterceptorTest.java
+++ b/brave-client/src/test/java/com/github/kristofa/brave/client/ClientResponseInterceptorTest.java
@@ -26,7 +26,7 @@ public class ClientResponseInterceptorTest {
         clientResponseAdapter = mock(ClientResponseAdapter.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testBraveHttpRequestInterceptor() {
         new ClientResponseInterceptor(null);
     }

--- a/brave-impl-spring/pom.xml
+++ b/brave-impl-spring/pom.xml
@@ -83,9 +83,13 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>      
-        </plugin>        
-        </plugins>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
   
 </project>

--- a/brave-impl/pom.xml
+++ b/brave-impl/pom.xml
@@ -33,9 +33,13 @@
         <version>3.0.0-beta-1-SNAPSHOT</version>
     </dependency>
     <dependency>
+        <!-- For @javax.annotation.Nullable -->
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.1</version>
     </dependency>
   </dependencies>
   
@@ -63,11 +67,12 @@
             </plugin>
             <plugin>
             	<groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-failsafe-plugin</artifactId>		
-	    </plugin>        
-        </plugins>
-        
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
-  
-
 </project>

--- a/brave-impl/src/main/java/com/github/kristofa/brave/AnnotationSubmitterImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/AnnotationSubmitterImpl.java
@@ -1,6 +1,6 @@
 package com.github.kristofa.brave;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;

--- a/brave-impl/src/main/java/com/github/kristofa/brave/BraveExecutorService.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/BraveExecutorService.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeoutException;
 
 import javax.annotation.PreDestroy;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * {@link ExecutorService} that wraps around an existing {@link ExecutorService} and that makes sure the threads are executed

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -2,6 +2,8 @@ package com.github.kristofa.brave;
 
 import java.util.Collection;
 
+import javax.annotation.Nullable;
+
 public interface ClientRequestAdapter {
 
     /**
@@ -15,10 +17,10 @@ public interface ClientRequestAdapter {
      * Enrich the request with the Spanid so we pass the state to the
      * service we are calling.
      *
-     * @param spanId Nullable span id. If empty we don't need to trace request and you
+     * @param spanId Nullable span id. If null we don't need to trace request and you
      *               should pass an indication along with the request that indicates we won't trace this request.
      */
-    void addSpanIdToRequest(SpanId spanId);
+    void addSpanIdToRequest(@Nullable SpanId spanId);
 
     /**
      * Returns the service name for request. The service name is expected to be the same

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ClientSpanThreadBinderImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ClientSpanThreadBinderImpl.java
@@ -1,7 +1,7 @@
 package com.github.kristofa.brave;
 
 import com.twitter.zipkin.gen.Span;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Created by hzhao on 8/11/14.

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ClientTracerImpl.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ClientTracerImpl.java
@@ -145,10 +145,10 @@ class ClientTracerImpl extends AbstractAnnotationSubmitter implements ClientTrac
         final Span currentServerSpan = state.getCurrentServerSpan().getSpan();
         final long newSpanId = randomGenerator.nextLong();
         if (currentServerSpan == null) {
-            return new SpanId(newSpanId, newSpanId, Optional.<Long>empty());
+            return new SpanId(newSpanId, newSpanId, null);
         }
 
-        return new SpanId(currentServerSpan.getTrace_id(), newSpanId, Optional.of(currentServerSpan.getId()));
+        return new SpanId(currentServerSpan.getTrace_id(), newSpanId, currentServerSpan.getId());
     }
 
 }

--- a/brave-impl/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
@@ -1,11 +1,8 @@
 package com.github.kristofa.brave;
 
-
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Contains logic for handling an incoming server request.
@@ -19,7 +16,7 @@ public class ServerRequestInterceptor {
     private final ServerTracer serverTracer;
 
     public ServerRequestInterceptor(ServerTracer serverTracer) {
-        this.serverTracer = Objects.requireNonNull(serverTracer, "serverTracer should not be null.");
+        this.serverTracer = Validate.notNull(serverTracer, "serverTracer should not be null.");
     }
 
     /**
@@ -31,16 +28,16 @@ public class ServerRequestInterceptor {
         serverTracer.clearCurrentSpan();
         final TraceData traceData = adapter.getTraceData();
 
-        Optional<Boolean> sample = traceData.getSample();
-        if (sample.isPresent() && Boolean.FALSE.equals(sample.get())) {
+        Boolean sample = traceData.getSample();
+        if (sample != null && Boolean.FALSE.equals(sample)) {
             serverTracer.setStateNoTracing();
             LOGGER.debug("Received indication that we should NOT trace.");
         } else {
-            if (traceData.getSpanId().isPresent()) {
+            if (traceData.getSpanId() != null) {
                 LOGGER.debug("Received span information as part of request.");
-                SpanId spanId = traceData.getSpanId().get();
+                SpanId spanId = traceData.getSpanId();
                 serverTracer.setStateCurrentTrace(spanId.getTraceId(), spanId.getSpanId(),
-                        spanId.getOptionalParentSpanId().orElse(null), adapter.getSpanName());
+                        spanId.getParentSpanId(), adapter.getSpanName());
             } else {
                 LOGGER.debug("Received no span state.");
                 serverTracer.setStateUnknown(adapter.getSpanName());

--- a/brave-impl/src/main/java/com/github/kristofa/brave/TraceData.java
+++ b/brave-impl/src/main/java/com/github/kristofa/brave/TraceData.java
@@ -1,28 +1,30 @@
 package com.github.kristofa.brave;
 
-import java.util.Objects;
-import java.util.Optional;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.annotation.Nullable;
 
 /**
  * Trace properties we potentially get from incoming request.
  */
 public class TraceData {
 
-    private final Optional<SpanId> spanId;
-    private final Optional<Boolean> sample;
+    private final SpanId spanId;
+    private final Boolean sample;
 
     public static class Builder {
 
-        private Optional<SpanId> spanId = Optional.empty();
-        private Optional<Boolean> sample = Optional.empty();
+        private SpanId spanId;
+        private Boolean sample;
 
-        public Builder spanId(SpanId spanId) {
-            this.spanId = Optional.of(spanId);
+        public Builder spanId(@Nullable SpanId spanId) {
+            this.spanId = spanId;
             return this;
         }
 
-        public Builder sample(boolean sample) {
-            this.sample = Optional.of(sample);
+        public Builder sample(@Nullable boolean sample) {
+            this.sample = sample;
             return this;
         }
 
@@ -40,24 +42,26 @@ public class TraceData {
     /**
      * Span id.
      *
-     * @return Span id.
+     * @return Nullable Span id.
      */
-    public Optional<SpanId> getSpanId() {
+    @Nullable
+    public SpanId getSpanId() {
         return spanId;
     }
 
     /**
      * Indication of request should be sampled or not.
      *
-     * @return Indication if request should be sampled or not.
+     * @return Nullable Indication if request should be sampled or not.
      */
-    public Optional<Boolean> getSample() {
+    @Nullable
+    public Boolean getSample() {
         return sample;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(spanId, sample);
+        return new HashCodeBuilder().append(spanId).append(sample).toHashCode();
     }
 
     @Override
@@ -67,8 +71,9 @@ public class TraceData {
         }
         if (obj instanceof TraceData) {
             final TraceData other = (TraceData) obj;
-            return Objects.equals(this.sample, other.sample) &&
-                    Objects.equals(this.spanId, other.spanId);
+            return new EqualsBuilder()
+                .append(this.sample, other.sample)
+                .append(this.spanId, other.spanId).isEquals();
         }
         return false;
     }

--- a/brave-impl/src/test/java/com/github/kristofa/brave/AnnotationSubmitterImplTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/AnnotationSubmitterImplTest.java
@@ -41,7 +41,7 @@ public class AnnotationSubmitterImplTest {
         assertSame(mockEndPoint, annotationSubmitter.getEndPoint());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testAnnotationSubmitterImpl() {
         new AnnotationSubmitterImpl(null);
     }

--- a/brave-impl/src/test/java/com/github/kristofa/brave/ClientSpanThreadBinderImplTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/ClientSpanThreadBinderImplTest.java
@@ -25,7 +25,7 @@ public class ClientSpanThreadBinderImplTest {
         mockSpan = mock(Span.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testConstructorNullState() {
         new ClientSpanThreadBinderImpl(null);
     }

--- a/brave-impl/src/test/java/com/github/kristofa/brave/ITBrave.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/ITBrave.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.junit.Test;
 
 import com.twitter.zipkin.gen.Span;
@@ -135,7 +134,7 @@ public class ITBrave {
 
         @Override
         public void addDefaultAnnotation(final String name, final String value) {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/brave-impl/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/ServerRequestInterceptorTest.java
@@ -7,7 +7,6 @@ import org.mockito.InOrder;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 
@@ -59,7 +58,7 @@ public class ServerRequestInterceptorTest {
 
     @Test
     public void handleSampleRequestWithParentSpanId() {
-        TraceData traceData = new TraceData.Builder().spanId(new SpanId(TRACE_ID, SPAN_ID, Optional.of(PARENT_SPAN_ID))).sample(true).build();
+        TraceData traceData = new TraceData.Builder().spanId(new SpanId(TRACE_ID, SPAN_ID, PARENT_SPAN_ID)).sample(true).build();
         when(adapter.getTraceData()).thenReturn(traceData);
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Arrays.asList(ANNOTATION1, ANNOTATION2));
@@ -77,7 +76,7 @@ public class ServerRequestInterceptorTest {
 
     @Test
     public void handleSampleRequestWithoutParentSpanId() {
-        TraceData traceData = new TraceData.Builder().spanId(new SpanId(TRACE_ID, SPAN_ID, Optional.empty())).sample(true).build();
+        TraceData traceData = new TraceData.Builder().spanId(new SpanId(TRACE_ID, SPAN_ID, null)).sample(true).build();
         when(adapter.getTraceData()).thenReturn(traceData);
         when(adapter.getSpanName()).thenReturn(SPAN_NAME);
         when(adapter.requestAnnotations()).thenReturn(Collections.EMPTY_LIST);

--- a/brave-impl/src/test/java/com/github/kristofa/brave/TraceDataTest.java
+++ b/brave-impl/src/test/java/com/github/kristofa/brave/TraceDataTest.java
@@ -3,28 +3,27 @@ package com.github.kristofa.brave;
 
 import org.junit.Test;
 
-import java.util.Optional;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TraceDataTest {
 
     private static final boolean SAMPLE = true;
-    private static final SpanId SPAN_ID = new SpanId(3454, 3353, Optional.of(34343l));
+    private static final SpanId SPAN_ID = new SpanId(3454, 3353, 34343l);
 
 
     @Test
     public void testDefaultTraceData() {
         TraceData defaultTraceData = new TraceData.Builder().build();
-        assertEquals(Optional.empty(), defaultTraceData.getSample());
-        assertEquals(Optional.empty(), defaultTraceData.getSpanId());
+        assertNull(defaultTraceData.getSample());
+        assertNull(defaultTraceData.getSpanId());
     }
 
     @Test
     public void testTraceDataConstruction() {
         TraceData traceData = new TraceData.Builder().sample(SAMPLE).spanId(SPAN_ID).build();
-        assertEquals(Optional.of(SAMPLE), traceData.getSample());
-        assertEquals(Optional.of(SPAN_ID), traceData.getSpanId());
+        assertEquals(SAMPLE, traceData.getSample());
+        assertEquals(SPAN_ID, traceData.getSpanId());
     }
 
 }

--- a/brave-interfaces/pom.xml
+++ b/brave-interfaces/pom.xml
@@ -27,6 +27,15 @@
 
   <dependencies>
     <dependency>
+        <!-- For @javax.annotation.Nullable -->
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
         <version>0.9.0</version>
@@ -68,8 +77,12 @@
             <plugin>
             	<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>		
-	    	</plugin>        
-        </plugins>          
+	    	</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
   
 

--- a/brave-interfaces/src/main/java/com/github/kristofa/brave/SpanId.java
+++ b/brave-interfaces/src/main/java/com/github/kristofa/brave/SpanId.java
@@ -1,7 +1,9 @@
 package com.github.kristofa.brave;
 
-import java.util.Objects;
-import java.util.Optional;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import javax.annotation.Nullable;
 
 /**
  * Identifies a Span.
@@ -12,19 +14,19 @@ public class SpanId {
 
     private final long traceId;
     private final long spanId;
-    private final Optional<Long> parentSpanId;
+    private final Long parentSpanId;
 
     /**
      * Creates a new span id.
      *
      * @param traceId Trace Id.
      * @param spanId Span Id.
-     * @param parentSpanId Optional parent span id.
+     * @param parentSpanId Nullable parent span id.
      */
-    public SpanId(final long traceId, final long spanId, final Optional<Long> parentSpanId) {
+    public SpanId(final long traceId, final long spanId, @Nullable final Long parentSpanId) {
         this.traceId = traceId;
         this.spanId = spanId;
-        this.parentSpanId = Objects.requireNonNull(parentSpanId, "null is not allowed, you should use Optional.empty()");
+        this.parentSpanId = parentSpanId;
     }
 
     /**
@@ -46,27 +48,19 @@ public class SpanId {
     }
 
     /**
-     * Deprecated. Please use getOptionalParentSpanId().
+     * Get parent span id.
      *
      * @return Parent span id. Can be <code>null</code>.
      */
-    @Deprecated
+    @Nullable
     public Long getParentSpanId() {
-        return parentSpanId.orElse(null);
-    }
-
-    /**
-     * Get parent span id.
-     *
-     * @return Optional parent span id.
-     */
-    public Optional<Long> getOptionalParentSpanId() {
         return parentSpanId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(traceId, spanId, parentSpanId);
+        return new HashCodeBuilder()
+            .append(traceId).append(spanId).append(parentSpanId).toHashCode();
     }
 
     @Override
@@ -76,9 +70,10 @@ public class SpanId {
         }
         if (obj instanceof SpanId) {
             final SpanId other = (SpanId) obj;
-            return Objects.equals(this.traceId, other.traceId) &&
-                    Objects.equals(this.spanId, other.spanId) &&
-                    Objects.equals(this.parentSpanId, other.parentSpanId);
+            return new EqualsBuilder()
+                .append(this.traceId, other.traceId)
+                .append(this.spanId, other.spanId)
+                .append(this.parentSpanId, other.parentSpanId).isEquals();
         }
         else
         {
@@ -92,6 +87,6 @@ public class SpanId {
     @Override
     public String toString() {
         return "[trace id: " + traceId + ", span id: " + spanId + ", parent span id: "
-                + parentSpanId.toString() + "]";
+                + parentSpanId + "]";
     }
 }

--- a/brave-interfaces/src/test/java/com/github/kristofa/brave/SpanIdTest.java
+++ b/brave-interfaces/src/test/java/com/github/kristofa/brave/SpanIdTest.java
@@ -4,8 +4,6 @@ package com.github.kristofa.brave;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Optional;
-
 import static org.junit.Assert.*;
 
 public class SpanIdTest {
@@ -18,12 +16,12 @@ public class SpanIdTest {
 
     @Before
     public void setup() {
-        spanIdImpl = new SpanId(TRACEID, SPANID, Optional.of(PARENT_SPANID));
+        spanIdImpl = new SpanId(TRACEID, SPANID, PARENT_SPANID);
     }
 
     @Test
     public void testSpanIdNullParentId() {
-        final SpanId spanIdImpl2 = new SpanId(TRACEID, SPANID, Optional.empty());
+        final SpanId spanIdImpl2 = new SpanId(TRACEID, SPANID, null);
         assertNull(spanIdImpl2.getParentSpanId());
     }
 
@@ -44,13 +42,13 @@ public class SpanIdTest {
 
     @Test
     public void testGetOptionalParentSpanId() {
-        assertEquals(Optional.of(PARENT_SPANID), spanIdImpl.getOptionalParentSpanId());
+        assertEquals(PARENT_SPANID, spanIdImpl.getParentSpanId());
     }
 
 
     @Test
     public void testHashCode() {
-        final SpanId equalSpanId = new SpanId(TRACEID, SPANID, Optional.of(PARENT_SPANID));
+        final SpanId equalSpanId = new SpanId(TRACEID, SPANID, PARENT_SPANID);
         assertEquals(spanIdImpl.hashCode(), equalSpanId.hashCode());
     }
 
@@ -60,29 +58,27 @@ public class SpanIdTest {
         assertFalse(spanIdImpl.equals(null));
         assertFalse(spanIdImpl.equals(new String()));
 
-        final SpanId equalSpanId = new SpanId(TRACEID, SPANID, Optional.of(PARENT_SPANID));
+        final SpanId equalSpanId = new SpanId(TRACEID, SPANID, PARENT_SPANID);
         assertTrue(spanIdImpl.equals(equalSpanId));
 
-        final SpanId nonEqualSpanId = new SpanId(TRACEID + 1, SPANID, Optional.of(PARENT_SPANID));
-        final SpanId nonEqualSpanId2 = new SpanId(TRACEID, SPANID + 1, Optional.of(PARENT_SPANID));
-        final SpanId nonEqualSpanId3 = new SpanId(TRACEID, SPANID, Optional.of(PARENT_SPANID + 1));
+        final SpanId nonEqualSpanId = new SpanId(TRACEID + 1, SPANID, PARENT_SPANID);
+        final SpanId nonEqualSpanId2 = new SpanId(TRACEID, SPANID + 1, PARENT_SPANID);
+        final SpanId nonEqualSpanId3 = new SpanId(TRACEID, SPANID, PARENT_SPANID + 1);
 
         assertFalse(spanIdImpl.equals(nonEqualSpanId));
         assertFalse(spanIdImpl.equals(nonEqualSpanId2));
         assertFalse(spanIdImpl.equals(nonEqualSpanId3));
     }
 
-
-
     @Test
     public void testToString() {
-        assertEquals("[trace id: " + TRACEID + ", span id: " + SPANID + ", parent span id: Optional[" + PARENT_SPANID + "]]",
+        assertEquals("[trace id: " + TRACEID + ", span id: " + SPANID + ", parent span id: " + PARENT_SPANID + "]",
                 spanIdImpl.toString());
     }
 
     @Test
     public void testToStringNullParent() {
-        final SpanId spanIdImpl2 = new SpanId(TRACEID, SPANID, Optional.empty());
-        assertEquals("[trace id: " + TRACEID + ", span id: " + SPANID + ", parent span id: Optional.empty]", spanIdImpl2.toString());
+        final SpanId spanIdImpl2 = new SpanId(TRACEID, SPANID, null);
+        assertEquals("[trace id: " + TRACEID + ", span id: " + SPANID + ", parent span id: null]", spanIdImpl2.toString());
     }
 }

--- a/brave-jaxrs2/pom.xml
+++ b/brave-jaxrs2/pom.xml
@@ -91,6 +91,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientRequestFilter.java
@@ -3,7 +3,7 @@ package com.github.kristofa.brave.jaxrs2;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveClientResponseFilter.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave.jaxrs2;
 
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientResponseInterceptor;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.ClientRequestContext;

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
@@ -5,7 +5,7 @@ import com.github.kristofa.brave.EndPointSubmitter;
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.ServerTracer;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/brave-jersey/pom.xml
+++ b/brave-jersey/pom.xml
@@ -72,8 +72,12 @@
             <plugin>
             	<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>		
-	    	</plugin>        
-        </plugins>  
+	    	</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+       </plugins>
   </build>
 
 </project>

--- a/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
+++ b/brave-jersey/src/main/java/com/github/kristofa/brave/jersey/JerseyClientTraceFilter.java
@@ -3,7 +3,7 @@ package com.github.kristofa.brave.jersey;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientRequestInterceptor;

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -109,6 +109,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/brave-mysql/pom.xml
+++ b/brave-mysql/pom.xml
@@ -62,7 +62,11 @@
             	<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 	    	</plugin>
-        </plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+       </plugins>
   </build>
 
 </project>

--- a/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorTest.java
+++ b/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorTest.java
@@ -11,7 +11,7 @@ import org.mockito.InOrder;
 
 import java.sql.SQLException;
 
-import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -34,9 +34,13 @@
         <version>3.0.0-beta-1-SNAPSHOT</version>
     </dependency>
     <dependency>
+        <!-- For @javax.annotation.Nullable -->
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.1</version>
     </dependency>
     <dependency>
 		<groupId>org.jboss.resteasy</groupId>
@@ -123,11 +127,12 @@
             </plugin>
             <plugin>
             	<groupId>org.apache.maven.plugins</groupId>
-		          <artifactId>maven-failsafe-plugin</artifactId>		
-	    </plugin>        
-        </plugins>
-        
+                <artifactId>maven-failsafe-plugin</artifactId>
+	        </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
-  
-
 </project>

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
@@ -1,8 +1,9 @@
 package com.github.kristofa.brave.resteasy;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.ext.Provider;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.jboss.resteasy.annotations.interception.ClientInterceptor;
 import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
@@ -63,7 +64,7 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
      * @param spanNameFilter Nullable {@link SpanNameFilter}
      */
     @Autowired(required = false)
-    public BraveClientExecutionInterceptor(final ClientTracer clientTracer, final SpanNameFilter spanNameFilter) {
+    public BraveClientExecutionInterceptor(final ClientTracer clientTracer, @Nullable final SpanNameFilter spanNameFilter) {
         Validate.notNull(clientTracer);
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);

--- a/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptorTest.java
+++ b/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptorTest.java
@@ -56,7 +56,7 @@ public class BraveClientExecutionInterceptorTest {
         interceptor = new BraveClientExecutionInterceptor(mockClientTracer);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testBraveClientExecutionInterceptor() {
         new BraveClientExecutionInterceptor(null);
     }

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.1</version>
     </dependency>
 
 	<dependency>
@@ -129,11 +128,12 @@
             </plugin>
             <plugin>
             	<groupId>org.apache.maven.plugins</groupId>
-		          <artifactId>maven-failsafe-plugin</artifactId>		
-	    </plugin>        
-        </plugins>
-        
+                <artifactId>maven-failsafe-plugin</artifactId>
+	        </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
-  
-
 </project>

--- a/brave-tracefilters/pom.xml
+++ b/brave-tracefilters/pom.xml
@@ -69,7 +69,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>      
-            </plugin>        
-        </plugins>  
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
 </project>

--- a/brave-tracefilters/src/main/java/com/github/kristofa/brave/tracefilter/ZooKeeperSamplingTraceFilter.java
+++ b/brave-tracefilters/src/main/java/com/github/kristofa/brave/tracefilter/ZooKeeperSamplingTraceFilter.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.PreDestroy;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;

--- a/brave-zipkin-spancollector/pom.xml
+++ b/brave-zipkin-spancollector/pom.xml
@@ -40,7 +40,6 @@
       <dependency>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
-          <version>3.3.1</version>
       </dependency>
   </dependencies>
   <build>	
@@ -68,8 +67,11 @@
             <plugin>
             	<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>		
-	    	</plugin>        
-        </plugins>  
+	    	</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+            </plugin>
+    </plugins>
   </build>
-  
 </project>

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SpanProcessingThread.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SpanProcessingThread.java
@@ -8,7 +8,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinCollectorClientProvider.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinCollectorClientProvider.java
@@ -1,6 +1,6 @@
 package com.github.kristofa.brave.zipkin;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollectorParams.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollectorParams.java
@@ -1,6 +1,6 @@
 package com.github.kristofa.brave.zipkin;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Optional parameters for {@link ZipkinSpanCollector}.

--- a/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ZipkinCollectorReceiver.java
+++ b/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ZipkinCollectorReceiver.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -69,22 +68,19 @@ class ZipkinCollectorReceiver implements Iface {
     @Override
     public void storeTopAnnotations(final String service_name, final List<String> annotations)
         throws StoreAggregatesException, TException {
-        throw new NotImplementedException();
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void storeTopKeyValueAnnotations(final String service_name, final List<String> annotations)
         throws StoreAggregatesException, TException {
-        throw new NotImplementedException();
-
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void storeDependencies(final String service_name, final List<String> endpoints) throws StoreAggregatesException,
         TException {
-        throw new NotImplementedException();
-
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,17 @@
             <artifactId>spring-test</artifactId>
             <version>${spring.version}</version>
         </dependency>
+        <dependency>
+            <!-- For @javax.annotation.Nullable -->
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
 		<dependency>
 		        <groupId>org.apache.httpcomponents</groupId>
 		        <artifactId>httpcore</artifactId>


### PR DESCRIPTION
This completes migration off Java 8, particularly by enabling the
animal-sniffer plugin, left disabled by accident.

This moves use of Optional to javax.annotation.Nullable. The latter
annotation will be read by auto-value's annotation processor in the near
future.

This also consolidates explicit use of commons-lang3, most of which will
also be removed via auto-value generated code.

See #73