### PR TITLE
Removes dependency on commons-lang3 for Base64

### DIFF
--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/Base64.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/Base64.java
@@ -1,0 +1,50 @@
+package com.github.kristofa.brave.zipkin;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Adapted from <a href="https://github.com/square/okio/blob/master/okio/src/main/java/okio/Base64.java">okio</a>
+ * @author Alexander Y. Kleymenov
+ */
+final class Base64 {
+  private Base64() {
+  }
+
+  private static final byte[] MAP = new byte[] {
+      'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S',
+      'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+      'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4',
+      '5', '6', '7', '8', '9', '+', '/'
+  };
+
+  static String encode(byte[] in) {
+    int length = (in.length + 2) * 4 / 3;
+    byte[] out = new byte[length];
+    int index = 0, end = in.length - in.length % 3;
+    for (int i = 0; i < end; i += 3) {
+      out[index++] = MAP[(in[i] & 0xff) >> 2];
+      out[index++] = MAP[((in[i] & 0x03) << 4) | ((in[i + 1] & 0xff) >> 4)];
+      out[index++] = MAP[((in[i + 1] & 0x0f) << 2) | ((in[i + 2] & 0xff) >> 6)];
+      out[index++] = MAP[(in[i + 2] & 0x3f)];
+    }
+    switch (in.length % 3) {
+      case 1:
+        out[index++] = MAP[(in[end] & 0xff) >> 2];
+        out[index++] = MAP[(in[end] & 0x03) << 4];
+        out[index++] = '=';
+        out[index++] = '=';
+        break;
+      case 2:
+        out[index++] = MAP[(in[end] & 0xff) >> 2];
+        out[index++] = MAP[((in[end] & 0x03) << 4) | ((in[end + 1] & 0xff) >> 4)];
+        out[index++] = MAP[((in[end + 1] & 0x0f) << 2)];
+        out[index++] = '=';
+        break;
+    }
+    try {
+      return new String(out, 0, index, "US-ASCII");
+    } catch (UnsupportedEncodingException e) {
+      throw new AssertionError(e);
+    }
+  }
+}

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SpanProcessingThread.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/SpanProcessingThread.java
@@ -7,7 +7,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.Validate;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -39,7 +38,6 @@ class SpanProcessingThread implements Callable<Integer> {
 
     private final BlockingQueue<Span> queue;
     private final ZipkinCollectorClientProvider clientProvider;
-    private final Base64 base64 = new Base64();
     private final TProtocolFactory protocolFactory;
     private volatile boolean stop = false;
     private int processedSpans = 0;
@@ -138,7 +136,7 @@ class SpanProcessingThread implements Callable<Integer> {
     }
 
     private LogEntry create(final Span span) throws TException {
-        final String spanAsString = base64.encodeToString(spanToBytes(span));
+        final String spanAsString = Base64.encode(spanToBytes(span));
         return new LogEntry("zipkin", spanAsString);
     }
 

--- a/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ZipkinCollectorReceiver.java
+++ b/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ZipkinCollectorReceiver.java
@@ -2,9 +2,9 @@ package com.github.kristofa.brave.zipkin;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -37,10 +37,8 @@ class ZipkinCollectorReceiver implements Iface {
     public ResultCode Log(final List<LogEntry> messages) throws TException {
         try {
 
-            final Base64 base64 = new Base64();
-
             for (final LogEntry logEntry : messages) {
-                final byte[] decodedSpan = base64.decode(logEntry.getMessage());
+                final byte[] decodedSpan = Base64.getDecoder().decode(logEntry.getMessage());
 
                 final ByteArrayInputStream buf = new ByteArrayInputStream(decodedSpan);
                 final TProtocolFactory factory = new TBinaryProtocol.Factory();


### PR DESCRIPTION
This is part of a few changes needed to remove an explicit dependency on
commons-lang3. In this change, we host a local base64 decoder, copied
from okio (under ASL). This decoder is only used once and is 50 loc.

Tests do not have a Java 7 constraint, so can use the built-in Java 8
Base64 codec as opposed to the one from apache commons.