### PR TITLE
Makes brave-core dependency free

### DIFF
--- a/brave-apache-http-interceptors/pom.xml
+++ b/brave-apache-http-interceptors/pom.xml
@@ -24,29 +24,18 @@
   </properties>
   <dependencies>
     <dependency>
-       <!-- For @javax.annotation.Nullable -->
-       <groupId>com.google.code.findbugs</groupId>
-       <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpclient</artifactId>
-        <version>4.3.3</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.3.2</version>
     </dependency>
     <dependency>
         <groupId>com.github.kristofa</groupId>
         <artifactId>brave-http</artifactId>
         <version>3.0.0-alpha-2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <scope>test</scope>
     </dependency>
     <dependency>
         <groupId>com.github.kristofa</groupId>

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpRequestInterceptor.java
@@ -1,15 +1,15 @@
 package com.github.kristofa.brave.httpclient;
 
-import org.apache.commons.lang3.Validate;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.client.ClientRequestInterceptor;
+import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
+import com.github.kristofa.brave.internal.Nullable;
+
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.protocol.HttpContext;
 
-import com.github.kristofa.brave.ClientTracer;
-import com.github.kristofa.brave.client.ClientRequestInterceptor;
-import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-
-import javax.annotation.Nullable;
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * Apache HttpClient {@link HttpRequestInterceptor} that adds brave/zipkin annotations to outgoing client request.
@@ -37,7 +37,7 @@ public class BraveHttpRequestInterceptor implements HttpRequestInterceptor {
      */
     public BraveHttpRequestInterceptor(final ClientTracer clientTracer, @Nullable final String serviceName,
         @Nullable final SpanNameFilter spanNameFilter) {
-        Validate.notNull(clientTracer);
+        checkNotNull(clientTracer, "Null clientTracer");
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         this.serviceName = serviceName;
     }

--- a/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
+++ b/brave-apache-http-interceptors/src/main/java/com/github/kristofa/brave/httpclient/BraveHttpResponseInterceptor.java
@@ -2,13 +2,14 @@ package com.github.kristofa.brave.httpclient;
 
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.client.ClientResponseInterceptor;
-import org.apache.commons.lang3.Validate;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpResponseInterceptor;
 import org.apache.http.protocol.HttpContext;
 
 import java.io.IOException;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * Apache HttpClient {@link HttpResponseInterceptor} that gets the HttpResponse, inspects the state. If the response
@@ -26,7 +27,7 @@ public class BraveHttpResponseInterceptor implements HttpResponseInterceptor {
      * @param clientTracer ClientTracer. Should not be <code>null</code>.
      */
     public BraveHttpResponseInterceptor(final ClientTracer clientTracer) {
-        Validate.notNull(clientTracer);
+        checkNotNull(clientTracer, "Null clientTracer");
         this.traceResponseBuilder = new ClientResponseInterceptor(clientTracer);
     }
 

--- a/brave-core/README.md
+++ b/brave-core/README.md
@@ -73,7 +73,7 @@ All spans that are submitted by brave end up in a SpanCollector of your choice
 A SpanCollector is responsible for receiving spans and acting upon them. There are 2 
 SpanCollector implementations part of brave-impl: 
 
-*    `com.github.kristofa.brave.LoggingSpanCollector` : This SpanCollector simply logs spans through log4j. This can be used for testing / during development.
+*    `com.github.kristofa.brave.LoggingSpanCollector` : This SpanCollector simply logs spans through jul. This can be used for testing / during development.
 *    `com.github.kristofa.brave.EmptySpanCollector` : This SpanCollector does nothing with the spans it receives. Can be used when disabling tracing.
 
 The most interesting SpanCollector is the ZipkinSpanCollector. This one can be found in 

--- a/brave-core/pom.xml
+++ b/brave-core/pom.xml
@@ -27,11 +27,6 @@
 
   <dependencies>
     <dependency>
-        <!-- For @javax.annotation.Nullable -->
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value</artifactId>
         <scope>provided</scope>
@@ -39,17 +34,6 @@
     <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.9.0</version>
-	<exclusions>
-	   <exclusion>
-		<artifactId>org.apache.httpcomponents</artifactId>
-		<groupId>httpcore</groupId>
-	    </exclusion>
-	</exclusions>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.httpcomponents</groupId>
-        <artifactId>httpcore</artifactId>
     </dependency>
     <!-- to mock AnnotationSubmitter's calls to System.currentTimeMillis() -->
     <dependency>

--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveCallable.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveCallable.java
@@ -1,10 +1,9 @@
 package com.github.kristofa.brave;
 
-import com.google.auto.value.AutoValue;
-
 import java.util.concurrent.Callable;
 
-import javax.annotation.Nullable;
+import com.github.kristofa.brave.internal.Nullable;
+import com.google.auto.value.AutoValue;
 
 /**
  * Callable implementation that wraps another Callable and makes sure the wrapped Callable will be executed in the same

--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveExecutorService.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveExecutorService.java
@@ -1,5 +1,6 @@
 package com.github.kristofa.brave;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -10,8 +11,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import javax.annotation.PreDestroy;
-
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
@@ -20,14 +19,14 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  * <p/>
  * It uses {@link ServerTracer} and {@link ServerSpanThreadBinder} to accomplish this in a transparent way for the user.
  * <p/>
- * It also has {@link PreDestroy} annotation on {@link BraveExecutorService#shutdown()} method so the executor service is
+ * It also implements {@link Closeable}, calling {@link BraveExecutorService#shutdown()}, so the executor service is
  * shut down properly when for example using Spring.
  * 
  * @author kristof
  * @see BraveCallable
  * @see BraveRunnable
  */
-public class BraveExecutorService implements ExecutorService {
+public class BraveExecutorService implements ExecutorService, Closeable {
 
     private final ExecutorService wrappedExecutor;
     private final ServerSpanThreadBinder threadBinder;
@@ -115,7 +114,6 @@ public class BraveExecutorService implements ExecutorService {
      * {@inheritDoc}
      */
     @Override
-    @PreDestroy
     public void shutdown() {
         wrappedExecutor.shutdown();
     }
@@ -164,4 +162,11 @@ public class BraveExecutorService implements ExecutorService {
         return collection;
     }
 
+    /**
+     * Convenience for try-with-resources, or frameworks such as Spring that automatically process this.
+     **/
+    @Override
+    public void close() {
+        shutdown();
+    }
 }

--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveRunnable.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveRunnable.java
@@ -1,8 +1,7 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
-
-import javax.annotation.Nullable;
 
 /**
  * {@link Runnable} implementation that wraps another Runnable and makes sure the wrapped Runnable will be executed in the

--- a/brave-core/src/main/java/com/github/kristofa/brave/BraveTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/BraveTracer.java
@@ -1,15 +1,15 @@
 package com.github.kristofa.brave;
 
 import java.net.InetAddress;
+import java.util.logging.Logger;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.lang.String.format;
 
 public class BraveTracer {
     private static final String REQUEST_ANNOTATION = "request";
     private static final String FAILURE_ANNOTATION = "failure";
     
-    private final static Logger LOGGER = LoggerFactory.getLogger(BraveTracer.class);
+    private final static Logger LOGGER = Logger.getLogger(BraveTracer.class.getName());
 
 	ClientTracer clientTracer;
 	ServerTracer serverTracer;
@@ -87,7 +87,7 @@ public class BraveTracer {
 		if (enabled)
 		{
 			submitEndpoint(contextPath);
-	        LOGGER.debug("Received no span state.");
+	        LOGGER.fine("Received no span state.");
 	        serverTracer.setStateUnknown(contextPath);
 	        serverTracer.setServerReceived();
 		}
@@ -98,7 +98,7 @@ public class BraveTracer {
 		{
 	        final String localAddr = InetAddress.getLocalHost().getHostAddress();
 	        final int localPort =0;
-	        LOGGER.debug("Setting endpoint: addr: {}, port: {}, contextpath: {}", localAddr, localPort, contextPath);
+	        LOGGER.fine(format("Setting endpoint: addr: %s, port: %s, contextpath: %s", localAddr, localPort, contextPath));
 	        if (!endpointSubmitter.endpointSubmitted())
 	        {
 	        	endpointSubmitter.submit(localAddr, localPort, contextPath);

--- a/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ClientRequestAdapter.java
@@ -2,7 +2,7 @@ package com.github.kristofa.brave;
 
 import java.util.Collection;
 
-import javax.annotation.Nullable;
+import com.github.kristofa.brave.internal.Nullable;
 
 public interface ClientRequestAdapter {
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/LoggingSpanCollector.java
@@ -4,9 +4,8 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.twitter.zipkin.gen.AnnotationType;
 import com.twitter.zipkin.gen.BinaryAnnotation;
@@ -16,7 +15,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotBlank;
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
- * Simple {@link SpanCollector} implementation which logs the span through slf4j at INFO level.
+ * Simple {@link SpanCollector} implementation which logs the span through jul at INFO level.
  * <p/>
  * Can be used for testing and debugging.
  * 
@@ -30,12 +29,12 @@ public class LoggingSpanCollector implements SpanCollector {
     private final Set<BinaryAnnotation> defaultAnnotations = new LinkedHashSet<>();
 
     public LoggingSpanCollector() {
-        logger = LoggerFactory.getLogger(LoggingSpanCollector.class);
+        logger = Logger.getLogger(LoggingSpanCollector.class.getName());
     }
 
     public LoggingSpanCollector(String loggerName) {
         checkNotBlank(loggerName, "Null or blank loggerName");
-        logger = LoggerFactory.getLogger(loggerName);
+        logger = Logger.getLogger(loggerName);
     }
 
     /**
@@ -50,7 +49,7 @@ public class LoggingSpanCollector implements SpanCollector {
             }
         }
 
-        if (getLogger().isInfoEnabled()) {
+        if (getLogger().isLoggable(Level.INFO)) {
             getLogger().info(span.toString());
         }
     }

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerRequestInterceptor.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
@@ -12,7 +11,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  */
 public class ServerRequestInterceptor {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ServerRequestInterceptor.class);
+    private final static Logger LOGGER = Logger.getLogger(ServerRequestInterceptor.class.getName());
 
     private final ServerTracer serverTracer;
 
@@ -32,15 +31,15 @@ public class ServerRequestInterceptor {
         Boolean sample = traceData.getSample();
         if (sample != null && Boolean.FALSE.equals(sample)) {
             serverTracer.setStateNoTracing();
-            LOGGER.debug("Received indication that we should NOT trace.");
+            LOGGER.fine("Received indication that we should NOT trace.");
         } else {
             if (traceData.getSpanId() != null) {
-                LOGGER.debug("Received span information as part of request.");
+                LOGGER.fine("Received span information as part of request.");
                 SpanId spanId = traceData.getSpanId();
                 serverTracer.setStateCurrentTrace(spanId.getTraceId(), spanId.getSpanId(),
                         spanId.getParentSpanId(), adapter.getSpanName());
             } else {
-                LOGGER.debug("Received no span state.");
+                LOGGER.fine("Received no span state.");
                 serverTracer.setStateUnknown(adapter.getSpanName());
             }
             serverTracer.setServerReceived();

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerResponseInterceptor.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerResponseInterceptor.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
@@ -10,7 +9,7 @@ import static com.github.kristofa.brave.internal.Util.checkNotNull;
  */
 public class ServerResponseInterceptor {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(ServerResponseInterceptor.class);
+    private final static Logger LOGGER = Logger.getLogger(ServerResponseInterceptor.class.getName());
 
     private final ServerTracer serverTracer;
 
@@ -21,7 +20,7 @@ public class ServerResponseInterceptor {
     public void handle(ServerResponseAdapter adapter) {
         // We can submit this in any case. When server state is not set or
         // we should not trace this request nothing will happen.
-        LOGGER.debug("Sending server send.");
+        LOGGER.fine("Sending server send.");
         try {
             for(KeyValueAnnotation annotation : adapter.responseAnnotations())
             {

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpan.java
@@ -1,12 +1,11 @@
 package com.github.kristofa.brave;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
 
 import com.twitter.zipkin.gen.Span;
-
-import java.util.concurrent.atomic.AtomicLong;
-
-import javax.annotation.Nullable;
 
 /**
  * The ServerSpan is initialized by {@link ServerTracer} and keeps track of Trace/Span state of our service request.

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanState.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanState.java
@@ -1,8 +1,8 @@
 package com.github.kristofa.brave;
 
-import com.twitter.zipkin.gen.Endpoint;
+import com.github.kristofa.brave.internal.Nullable;
 
-import javax.annotation.Nullable;
+import com.twitter.zipkin.gen.Endpoint;
 
 /**
  * Maintains server span state.

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanThreadBinder.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerSpanThreadBinder.java
@@ -1,6 +1,6 @@
 package com.github.kristofa.brave;
 
-import javax.annotation.Nullable;
+import com.github.kristofa.brave.internal.Nullable;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/ServerTracer.java
@@ -1,15 +1,14 @@
 package com.github.kristofa.brave;
 
-import com.google.auto.value.AutoValue;
-
-import com.github.kristofa.brave.SpanAndEndpoint.ServerSpanAndEndpoint;
-import com.twitter.zipkin.gen.Span;
-import com.twitter.zipkin.gen.zipkinCoreConstants;
-
 import java.util.List;
 import java.util.Random;
 
-import javax.annotation.Nullable;
+import com.github.kristofa.brave.SpanAndEndpoint.ServerSpanAndEndpoint;
+import com.github.kristofa.brave.internal.Nullable;
+import com.google.auto.value.AutoValue;
+
+import com.twitter.zipkin.gen.Span;
+import com.twitter.zipkin.gen.zipkinCoreConstants;
 
 import static com.github.kristofa.brave.internal.Util.checkNotBlank;
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanAndEndpoint.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanAndEndpoint.java
@@ -1,11 +1,10 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
 
 import com.twitter.zipkin.gen.Endpoint;
 import com.twitter.zipkin.gen.Span;
-
-import javax.annotation.Nullable;
 
 public interface SpanAndEndpoint {
 

--- a/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/SpanId.java
@@ -1,8 +1,7 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
-
-import javax.annotation.Nullable;
 
 /**
  * Identifies a Span.

--- a/brave-core/src/main/java/com/github/kristofa/brave/TraceData.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/TraceData.java
@@ -1,8 +1,7 @@
 package com.github.kristofa.brave;
 
+import com.github.kristofa.brave.internal.Nullable;
 import com.google.auto.value.AutoValue;
-
-import javax.annotation.Nullable;
 
 /**
  * Trace properties we potentially get from incoming request.

--- a/brave-core/src/main/java/com/github/kristofa/brave/internal/Nullable.java
+++ b/brave-core/src/main/java/com/github/kristofa/brave/internal/Nullable.java
@@ -1,0 +1,10 @@
+package com.github.kristofa.brave.internal;
+
+/**
+ * Libraries such as Guice and AutoValue will process any annotation named {@code Nullable}.
+ * This avoids a dependency on one of the many jsr305 jars.
+ */
+@java.lang.annotation.Documented
+@java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+public @interface Nullable {
+}

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Annotation.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Annotation.java
@@ -6,30 +6,19 @@
  */
 package com.twitter.zipkin.gen;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Annotation implements org.apache.thrift.TBase<Annotation, Annotation._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("Annotation");
@@ -401,29 +390,16 @@ public class Annotation implements org.apache.thrift.TBase<Annotation, Annotatio
 
   @Override
   public int hashCode() {
-    HashCodeBuilder builder = new HashCodeBuilder();
-
-    boolean present_timestamp = true;
-    builder.append(present_timestamp);
-    if (present_timestamp)
-      builder.append(timestamp);
-
-    boolean present_value = true && (isSetValue());
-    builder.append(present_value);
-    if (present_value)
-      builder.append(value);
-
-    boolean present_host = true && (isSetHost());
-    builder.append(present_host);
-    if (present_host)
-      builder.append(host);
-
-    boolean present_duration = true && (isSetDuration());
-    builder.append(present_duration);
-    if (present_duration)
-      builder.append(duration);
-
-    return builder.toHashCode();
+    int h = 1;
+    h *= 1000003;
+    h ^= (timestamp >>> 32) ^ timestamp; // required
+    h *= 1000003;
+    h ^= isSetValue() ? value.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= isSetHost() ? host.hashCode() : 0; // optional
+    h *= 1000003;
+    h ^= isSetDuration() ? duration : 0; // optional
+    return h;
   }
 
   public int compareTo(Annotation other) {

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/AnnotationType.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/AnnotationType.java
@@ -6,11 +6,6 @@
  */
 package com.twitter.zipkin.gen;
 
-
-import java.util.Map;
-import java.util.HashMap;
-import org.apache.thrift.TEnum;
-
 public enum AnnotationType implements org.apache.thrift.TEnum {
   BOOL(0),
   BYTES(1),

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/BinaryAnnotation.java
@@ -6,30 +6,19 @@
  */
 package com.twitter.zipkin.gen;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.nio.ByteBuffer;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class BinaryAnnotation implements org.apache.thrift.TBase<BinaryAnnotation, BinaryAnnotation._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("BinaryAnnotation");
@@ -425,29 +414,16 @@ public class BinaryAnnotation implements org.apache.thrift.TBase<BinaryAnnotatio
 
   @Override
   public int hashCode() {
-    HashCodeBuilder builder = new HashCodeBuilder();
-
-    boolean present_key = true && (isSetKey());
-    builder.append(present_key);
-    if (present_key)
-      builder.append(key);
-
-    boolean present_value = true && (isSetValue());
-    builder.append(present_value);
-    if (present_value)
-      builder.append(value);
-
-    boolean present_annotation_type = true && (isSetAnnotation_type());
-    builder.append(present_annotation_type);
-    if (present_annotation_type)
-      builder.append(annotation_type.getValue());
-
-    boolean present_host = true && (isSetHost());
-    builder.append(present_host);
-    if (present_host)
-      builder.append(host);
-
-    return builder.toHashCode();
+    int h = 1;
+    h *= 1000003;
+    h ^= isSetKey() ? key.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= isSetValue() ? value.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= isSetAnnotation_type() ? annotation_type.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= isSetHost() ? host.hashCode() : 0; // optional
+    return h;
   }
 
   public int compareTo(BinaryAnnotation other) {

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Endpoint.java
@@ -6,30 +6,19 @@
  */
 package com.twitter.zipkin.gen;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Endpoint implements org.apache.thrift.TBase<Endpoint, Endpoint._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("Endpoint");
@@ -346,24 +335,14 @@ public class Endpoint implements org.apache.thrift.TBase<Endpoint, Endpoint._Fie
 
   @Override
   public int hashCode() {
-    HashCodeBuilder builder = new HashCodeBuilder();
-
-    boolean present_ipv4 = true;
-    builder.append(present_ipv4);
-    if (present_ipv4)
-      builder.append(ipv4);
-
-    boolean present_port = true;
-    builder.append(present_port);
-    if (present_port)
-      builder.append(port);
-
-    boolean present_service_name = true && (isSetService_name());
-    builder.append(present_service_name);
-    if (present_service_name)
-      builder.append(service_name);
-
-    return builder.toHashCode();
+    int h = 1;
+    h *= 1000003;
+    h ^= ipv4; // required
+    h *= 1000003;
+    h ^= port; // required
+    h *= 1000003;
+    h ^= isSetService_name() ? service_name.hashCode() : 0; // required
+    return h;
   }
 
   public int compareTo(Endpoint other) {

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/Span.java
@@ -6,30 +6,21 @@
  */
 package com.twitter.zipkin.gen;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.thrift.EncodingUtils;
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Span implements org.apache.thrift.TBase<Span, Span._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("Span");
@@ -619,44 +610,22 @@ public class Span implements org.apache.thrift.TBase<Span, Span._Fields>, java.i
 
   @Override
   public int hashCode() {
-    HashCodeBuilder builder = new HashCodeBuilder();
-
-    boolean present_trace_id = true;
-    builder.append(present_trace_id);
-    if (present_trace_id)
-      builder.append(trace_id);
-
-    boolean present_name = true && (isSetName());
-    builder.append(present_name);
-    if (present_name)
-      builder.append(name);
-
-    boolean present_id = true;
-    builder.append(present_id);
-    if (present_id)
-      builder.append(id);
-
-    boolean present_parent_id = true && (isSetParent_id());
-    builder.append(present_parent_id);
-    if (present_parent_id)
-      builder.append(parent_id);
-
-    boolean present_annotations = true && (isSetAnnotations());
-    builder.append(present_annotations);
-    if (present_annotations)
-      builder.append(annotations);
-
-    boolean present_binary_annotations = true && (isSetBinary_annotations());
-    builder.append(present_binary_annotations);
-    if (present_binary_annotations)
-      builder.append(binary_annotations);
-
-    boolean present_debug = true && (isSetDebug());
-    builder.append(present_debug);
-    if (present_debug)
-      builder.append(debug);
-
-    return builder.toHashCode();
+    int h = 1;
+    h *= 1000003;
+    h ^= (trace_id >>> 32) ^ trace_id; // required
+    h *= 1000003;
+    h ^= isSetName() ? name.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= (id >>> 32) ^ id; // required
+    h *= 1000003;
+    h ^= isSetParent_id() ? (parent_id >>> 32) ^ parent_id : 0; // optional
+    h *= 1000003;
+    h ^= isSetAnnotations() ? annotations.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= isSetBinary_annotations() ? binary_annotations.hashCode() : 0; // required
+    h *= 1000003;
+    h ^= isSetDebug() && debug ? 1231 : 1237; // optional
+    return h;
   }
 
   public int compareTo(Span other) {

--- a/brave-core/src/main/java/com/twitter/zipkin/gen/zipkinCoreConstants.java
+++ b/brave-core/src/main/java/com/twitter/zipkin/gen/zipkinCoreConstants.java
@@ -6,31 +6,6 @@
  */
 package com.twitter.zipkin.gen;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.apache.thrift.scheme.IScheme;
-import org.apache.thrift.scheme.SchemeFactory;
-import org.apache.thrift.scheme.StandardScheme;
-
-import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class zipkinCoreConstants {
 
   public static final String CLIENT_SEND = "cs";

--- a/brave-core/src/test/java/com/github/kristofa/brave/LoggingSpanCollectorTest.java
+++ b/brave-core/src/test/java/com/github/kristofa/brave/LoggingSpanCollectorTest.java
@@ -7,11 +7,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.nio.ByteBuffer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.slf4j.Logger;
 
 import com.twitter.zipkin.gen.AnnotationType;
 import com.twitter.zipkin.gen.BinaryAnnotation;
@@ -44,7 +45,7 @@ public class LoggingSpanCollectorTest {
     public void testCollect() {
         final Span mockSpan = mock(Span.class);
         spanCollector.collect(mockSpan);
-        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).isLoggable(Level.INFO);
         verifyNoMoreInteractions(mockLogger, mockSpan);
     }
 
@@ -62,7 +63,7 @@ public class LoggingSpanCollectorTest {
         final InOrder inOrder = inOrder(mockSpan, mockLogger);
 
         inOrder.verify(mockSpan).addToBinary_annotations(expectedBinaryAnnoration);
-        inOrder.verify(mockLogger).isInfoEnabled();
+        inOrder.verify(mockLogger).isLoggable(Level.INFO);
 
         verifyNoMoreInteractions(mockLogger, mockSpan);
     }
@@ -82,7 +83,7 @@ public class LoggingSpanCollectorTest {
 
         verify(mockSpan).addToBinary_annotations(expectedBinaryAnnoration);
         verify(mockSpan).addToBinary_annotations(expectedBinaryAnnoration2);
-        verify(mockLogger).isInfoEnabled();
+        verify(mockLogger).isLoggable(Level.INFO);
 
         verifyNoMoreInteractions(mockLogger, mockSpan);
     }

--- a/brave-http/pom.xml
+++ b/brave-http/pom.xml
@@ -27,14 +27,13 @@
 
     <dependencies>
         <dependency>
-            <!-- For @javax.annotation.Nullable -->
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.kristofa</groupId>
             <artifactId>brave-core</artifactId>
             <version>3.0.0-alpha-2-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
         </dependency>
     </dependencies>
 

--- a/brave-http/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/client/ClientRequestHeaders.java
@@ -1,7 +1,6 @@
 package com.github.kristofa.brave.client;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 import com.github.kristofa.brave.BraveHttpHeaders;
 import com.github.kristofa.brave.IdConversion;
@@ -11,12 +10,12 @@ public class ClientRequestHeaders {
 
     private static final String TRUE = "true";
     private static final String FALSE = "false";
-    private final static Logger LOGGER = LoggerFactory.getLogger(ClientRequestHeaders.class);
+    private final static Logger LOGGER = Logger.getLogger(ClientRequestHeaders.class.getName());
 
     public static void addTracingHeaders(final ClientRequestAdapter clientRequestAdapter, final SpanId spanId,
         final String spanName) {
         if (spanId != null) {
-            LOGGER.debug("Will trace request. Span Id returned from ClientTracer: {}", spanId);
+            LOGGER.fine("Will trace request. Span Id returned from ClientTracer: " + spanId);
             clientRequestAdapter.addHeader(BraveHttpHeaders.Sampled.getName(), TRUE);
             clientRequestAdapter.addHeader(BraveHttpHeaders.TraceId.getName(), IdConversion.convertToString(spanId.getTraceId()));
             clientRequestAdapter.addHeader(BraveHttpHeaders.SpanId.getName(), IdConversion.convertToString(spanId.getSpanId()));
@@ -28,7 +27,7 @@ public class ClientRequestHeaders {
                 clientRequestAdapter.addHeader(BraveHttpHeaders.SpanName.getName(), spanName);
             }
         } else {
-            LOGGER.debug("Will not trace request.");
+            LOGGER.fine("Will not trace request.");
             clientRequestAdapter.addHeader(BraveHttpHeaders.Sampled.getName(), FALSE);
         }
     }

--- a/brave-http/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
+++ b/brave-http/src/main/java/com/github/kristofa/brave/client/ClientRequestInterceptor.java
@@ -3,8 +3,7 @@ package com.github.kristofa.brave.client;
 import com.github.kristofa.brave.ClientTracer;
 import com.github.kristofa.brave.SpanId;
 import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
-
-import javax.annotation.Nullable;
+import com.github.kristofa.brave.internal.Nullable;
 
 import static com.github.kristofa.brave.internal.Util.checkNotNull;
 

--- a/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
+++ b/brave-jaxrs2/src/main/java/com/github/kristofa/brave/jaxrs2/BraveContainerRequestFilter.java
@@ -5,17 +5,17 @@ import com.github.kristofa.brave.EndpointSubmitter;
 import com.github.kristofa.brave.IdConversion;
 import com.github.kristofa.brave.ServerTracer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URI;
+import java.util.logging.Logger;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.ext.Provider;
+
+import static java.lang.String.format;
 
 /**
  * Intercepts incoming container requests and extracts any trace information from the request header
@@ -24,7 +24,7 @@ import javax.ws.rs.ext.Provider;
 @Provider
 public class BraveContainerRequestFilter implements ContainerRequestFilter {
 
-    private static Logger logger = LoggerFactory.getLogger(BraveContainerRequestFilter.class);
+    private static Logger logger = Logger.getLogger(BraveContainerRequestFilter.class.getName());
 
     private final ServerTracer serverTracer;
     private final EndpointSubmitter endpointSubmitter;
@@ -44,15 +44,15 @@ public class BraveContainerRequestFilter implements ContainerRequestFilter {
         TraceData traceData = getTraceDataFromHeaders(containerRequestContext);
         if (Boolean.FALSE.equals(traceData.shouldBeTraced())) {
             serverTracer.setStateNoTracing();
-            logger.debug("Not tracing request");
+            logger.fine("Not tracing request");
         } else {
             String spanName = getSpanName(traceData, uriInfo);
             if (traceData.getTraceId() != null && traceData.getSpanId() != null) {
-                logger.debug("Received span information as part of request");
+                logger.fine("Received span information as part of request");
                 serverTracer.setStateCurrentTrace(traceData.getTraceId(), traceData.getSpanId(),
                         traceData.getParentSpanId(), spanName);
             } else {
-                logger.debug("Received no span state");
+                logger.fine("Received no span state");
                 serverTracer.setStateUnknown(spanName);
             }
         }
@@ -66,7 +66,7 @@ public class BraveContainerRequestFilter implements ContainerRequestFilter {
             String localAddr = baseUri.getHost();
             int localPort = baseUri.getPort();
             endpointSubmitter.submit(localAddr, localPort, contextPath);
-            logger.debug("Setting endpoint: addr: {}, port: {}, contextpath: {}", localAddr, localPort, contextPath);
+            logger.fine(format("Setting endpoint: addr: %s, port: %s, contextpath: %s", localAddr, localPort, contextPath));
         }
     }
 

--- a/brave-jersey2/pom.xml
+++ b/brave-jersey2/pom.xml
@@ -53,6 +53,13 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- AbstractApplicationContext in ITBraveJersey2 requires commons-logging -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-inmemory</artifactId>

--- a/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/SpanCollectorForTesting.java
+++ b/brave-jersey2/src/test/java/com/github/kristofa/brave/jersey2/SpanCollectorForTesting.java
@@ -2,15 +2,14 @@ package com.github.kristofa.brave.jersey2;
 
 import com.github.kristofa.brave.SpanCollector;
 import com.twitter.zipkin.gen.Span;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 
 public class SpanCollectorForTesting implements SpanCollector {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(SpanCollectorForTesting.class);
+    private final static Logger LOGGER = Logger.getLogger(SpanCollectorForTesting.class.getName());
 
     private final List<Span> spans = new ArrayList<Span>();
 

--- a/brave-resteasy-spring/pom.xml
+++ b/brave-resteasy-spring/pom.xml
@@ -34,15 +34,6 @@
         <version>3.0.0-alpha-2-SNAPSHOT</version>
     </dependency>
     <dependency>
-        <!-- For @javax.annotation.Nullable -->
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
 		<groupId>org.jboss.resteasy</groupId>
 		<artifactId>resteasy-jaxrs</artifactId>
 		<version>${resteasy.version}</version>
@@ -63,6 +54,12 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-spring</artifactId>
         <version>${resteasy.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <!-- Resteasy uses slf4j at runtime -->
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
         <scope>test</scope>
     </dependency>
 	<dependency>

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BraveClientExecutionInterceptor.java
@@ -1,9 +1,13 @@
 package com.github.kristofa.brave.resteasy;
 
-import javax.annotation.Nullable;
 import javax.ws.rs.ext.Provider;
 
-import org.apache.commons.lang3.Validate;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.client.ClientRequestInterceptor;
+import com.github.kristofa.brave.client.ClientResponseInterceptor;
+import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
+import com.github.kristofa.brave.internal.Nullable;
+
 import org.jboss.resteasy.annotations.interception.ClientInterceptor;
 import org.jboss.resteasy.client.ClientRequest;
 import org.jboss.resteasy.client.ClientResponse;
@@ -12,10 +16,7 @@ import org.jboss.resteasy.spi.interception.ClientExecutionInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.github.kristofa.brave.ClientTracer;
-import com.github.kristofa.brave.client.ClientRequestInterceptor;
-import com.github.kristofa.brave.client.ClientResponseInterceptor;
-import com.github.kristofa.brave.client.spanfilter.SpanNameFilter;
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * {@link ClientExecutionInterceptor} that uses the {@link ClientTracer} to set up a new span. </p> It adds the necessary
@@ -65,7 +66,7 @@ public class BraveClientExecutionInterceptor implements ClientExecutionIntercept
      */
     @Autowired(required = false)
     public BraveClientExecutionInterceptor(final ClientTracer clientTracer, @Nullable final SpanNameFilter spanNameFilter) {
-        Validate.notNull(clientTracer);
+        checkNotNull(clientTracer, "Null clientTracer");
         clientRequestInterceptor = new ClientRequestInterceptor(clientTracer, spanNameFilter);
         clientResponseInterceptor = new ClientResponseInterceptor(clientTracer);
     }

--- a/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePostProcessInterceptor.java
+++ b/brave-resteasy-spring/src/main/java/com/github/kristofa/brave/resteasy/BravePostProcessInterceptor.java
@@ -1,17 +1,18 @@
 package com.github.kristofa.brave.resteasy;
 
+import java.util.logging.Logger;
+
 import javax.ws.rs.ext.Provider;
 
-import org.apache.commons.lang3.Validate;
 import org.jboss.resteasy.annotations.interception.ServerInterceptor;
 import org.jboss.resteasy.core.ServerResponse;
 import org.jboss.resteasy.spi.interception.PostProcessInterceptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.github.kristofa.brave.ServerTracer;
+
+import static com.github.kristofa.brave.internal.Util.checkNotNull;
 
 /**
  * Rest Easy {@link PostProcessInterceptor} that will submit server send state.
@@ -23,7 +24,7 @@ import com.github.kristofa.brave.ServerTracer;
 @ServerInterceptor
 public class BravePostProcessInterceptor implements PostProcessInterceptor {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(BravePostProcessInterceptor.class);
+    private final static Logger LOGGER = Logger.getLogger(BravePostProcessInterceptor.class.getName());
 
     private final ServerTracer serverTracer;
 
@@ -33,16 +34,15 @@ public class BravePostProcessInterceptor implements PostProcessInterceptor {
      * @param serverTracer {@link ServerTracer}. Should not be null.
      */
     @Autowired
-    public BravePostProcessInterceptor(final ServerTracer serverTracer) {
-        Validate.notNull(serverTracer);
-        this.serverTracer = serverTracer;
+    public BravePostProcessInterceptor(ServerTracer serverTracer) {
+        this.serverTracer = checkNotNull(serverTracer, "Null serverTracer");
     }
 
     @Override
     public void postProcess(final ServerResponse response) {
         // We can submit this in any case. When server state is not set or
         // we should not trace this request nothing will happen.
-        LOGGER.debug("Sending server send.");
+        LOGGER.fine("Sending server send.");
         try {
             serverTracer.setServerSend();
         } finally {

--- a/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/SpanCollectorForTesting.java
+++ b/brave-resteasy-spring/src/test/java/com/github/kristofa/brave/resteasy/SpanCollectorForTesting.java
@@ -2,16 +2,14 @@ package com.github.kristofa.brave.resteasy;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 import com.github.kristofa.brave.SpanCollector;
 import com.twitter.zipkin.gen.Span;
 
 public class SpanCollectorForTesting implements SpanCollector {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(SpanCollectorForTesting.class);
+    private final static Logger LOGGER = Logger.getLogger(SpanCollectorForTesting.class.getName());
 
     private final List<Span> spans = new ArrayList<Span>();
 

--- a/brave-resteasy3-spring/pom.xml
+++ b/brave-resteasy3-spring/pom.xml
@@ -38,11 +38,6 @@
           <artifactId>brave-jaxrs2</artifactId>
           <version>3.0.0-alpha-2-SNAPSHOT</version>
       </dependency>
-    <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-    </dependency>
-
 	<dependency>
     	<groupId>org.springframework</groupId>
 	    <artifactId>spring-core</artifactId>
@@ -58,6 +53,12 @@
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-spring</artifactId>
         <version>${resteasy.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <!-- Resteasy uses slf4j at runtime -->
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/SpanCollectorForTesting.java
+++ b/brave-resteasy3-spring/src/test/java/com/github/kristofa/brave/resteasy3/SpanCollectorForTesting.java
@@ -2,16 +2,14 @@ package com.github.kristofa.brave.resteasy3;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.logging.Logger;
 
 import com.github.kristofa.brave.SpanCollector;
 import com.twitter.zipkin.gen.Span;
 
 public class SpanCollectorForTesting implements SpanCollector {
 
-    private final static Logger LOGGER = LoggerFactory.getLogger(SpanCollectorForTesting.class);
+    private final static Logger LOGGER = Logger.getLogger(SpanCollectorForTesting.class.getName());
 
     private final List<Span> spans = new ArrayList<Span>();
 

--- a/brave-tracefilters/pom.xml
+++ b/brave-tracefilters/pom.xml
@@ -34,15 +34,20 @@
     <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-framework</artifactId>
-        <version>2.2.0-incubating</version>  
+        <version>2.8.0</version>
     </dependency>
     <dependency>
         <groupId>org.apache.curator</groupId>
         <artifactId>curator-test</artifactId>
-        <version>2.2.0-incubating</version>
+        <version>2.8.0</version>
         <scope>test</scope>  
     </dependency>
-    
+    <!-- Curator uses slf4j at runtime -->
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>   
     <plugins>

--- a/brave-zipkin-spancollector/pom.xml
+++ b/brave-zipkin-spancollector/pom.xml
@@ -42,9 +42,11 @@
         <artifactId>auto-value</artifactId>
         <scope>provided</scope>
     </dependency>
+    <!-- org.apache.thrift.ProcessFunction v0.9 uses SLF4J at runtime -->
     <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <scope>test</scope>
     </dependency>
   </dependencies>
   <build>	

--- a/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollectorParams.java
+++ b/brave-zipkin-spancollector/src/main/java/com/github/kristofa/brave/zipkin/ZipkinSpanCollectorParams.java
@@ -1,7 +1,5 @@
 package com.github.kristofa.brave.zipkin;
 
-import org.apache.commons.lang3.Validate;
-
 /**
  * Optional parameters for {@link ZipkinSpanCollector}.
  * <p/>
@@ -58,7 +56,7 @@ public class ZipkinSpanCollectorParams {
      * @param queueSize Queue size.
      */
     public void setQueueSize(final int queueSize) {
-        Validate.isTrue(queueSize > 0);
+        if (queueSize <= 0) throw new IllegalArgumentException("queueSize must be positive");
         this.queueSize = queueSize;
     }
 
@@ -77,7 +75,7 @@ public class ZipkinSpanCollectorParams {
      * @param batchSize Maximum batch size.
      */
     public void setBatchSize(final int batchSize) {
-        Validate.isTrue(batchSize > 0);
+        if (batchSize <= 0) throw new IllegalArgumentException("batchSize must be positive");
         this.batchSize = batchSize;
     }
 
@@ -96,7 +94,7 @@ public class ZipkinSpanCollectorParams {
      * @param nrOfThreads Number of parallel threads for submitting spans to collector.
      */
     public void setNrOfThreads(final int nrOfThreads) {
-        Validate.isTrue(nrOfThreads > 0);
+        if (nrOfThreads <= 0) throw new IllegalArgumentException("nrOfThreads must be positive");
         this.nrOfThreads = nrOfThreads;
     }
 
@@ -115,7 +113,7 @@ public class ZipkinSpanCollectorParams {
      * @param socketTimeout Socket time out in milliseconds. Should be >= 100;
      */
     public void setSocketTimeout(final int socketTimeout) {
-        Validate.isTrue(socketTimeout >= 100);
+        if (socketTimeout < 100) throw new IllegalArgumentException("socketTimeout must be >= 100");
         this.socketTimeout = socketTimeout;
     }
 

--- a/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/AdjustableRateException.java
+++ b/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/AdjustableRateException.java
@@ -6,29 +6,19 @@
  */
 package com.twitter.zipkin.gen;
 
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AdjustableRateException extends TException implements org.apache.thrift.TBase<AdjustableRateException, AdjustableRateException._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("AdjustableRateException");

--- a/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/LogEntry.java
+++ b/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/LogEntry.java
@@ -6,29 +6,18 @@
  */
 package com.twitter.zipkin.gen;
 
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LogEntry implements org.apache.thrift.TBase<LogEntry, LogEntry._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("LogEntry");

--- a/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/ResultCode.java
+++ b/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/ResultCode.java
@@ -6,11 +6,6 @@
  */
 package com.twitter.zipkin.gen;
 
-
-import java.util.Map;
-import java.util.HashMap;
-import org.apache.thrift.TEnum;
-
 public enum ResultCode implements org.apache.thrift.TEnum {
   OK(0),
   TRY_LATER(1);

--- a/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/StoreAggregatesException.java
+++ b/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/StoreAggregatesException.java
@@ -6,29 +6,19 @@
  */
 package com.twitter.zipkin.gen;
 
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class StoreAggregatesException extends TException implements org.apache.thrift.TBase<StoreAggregatesException, StoreAggregatesException._Fields>, java.io.Serializable, Cloneable {
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("StoreAggregatesException");

--- a/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/ZipkinCollector.java
+++ b/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/ZipkinCollector.java
@@ -6,29 +6,20 @@
  */
 package com.twitter.zipkin.gen;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ZipkinCollector {
 
@@ -276,7 +267,6 @@ public class ZipkinCollector {
   }
 
   public static class Processor<I extends Iface> extends com.twitter.zipkin.gen.scribe.Processor<I> implements org.apache.thrift.TProcessor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Processor.class.getName());
     public Processor(I iface) {
       super(iface, getProcessMap(new HashMap<String, org.apache.thrift.ProcessFunction<I, ? extends org.apache.thrift.TBase>>()));
     }

--- a/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/scribe.java
+++ b/brave-zipkin-spancollector/src/main/java/com/twitter/zipkin/gen/scribe.java
@@ -6,29 +6,20 @@
  */
 package com.twitter.zipkin.gen;
 
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.thrift.protocol.TTupleProtocol;
 import org.apache.thrift.scheme.IScheme;
 import org.apache.thrift.scheme.SchemeFactory;
 import org.apache.thrift.scheme.StandardScheme;
-
 import org.apache.thrift.scheme.TupleScheme;
-import org.apache.thrift.protocol.TTupleProtocol;
-import org.apache.thrift.protocol.TProtocolException;
-import org.apache.thrift.EncodingUtils;
-import org.apache.thrift.TException;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.EnumMap;
-import java.util.Set;
-import java.util.HashSet;
-import java.util.EnumSet;
-import java.util.Collections;
-import java.util.BitSet;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class scribe {
 
@@ -140,7 +131,6 @@ public class scribe {
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift.TBaseProcessor<I> implements org.apache.thrift.TProcessor {
-    private static final Logger LOGGER = LoggerFactory.getLogger(Processor.class.getName());
     public Processor(I iface) {
       super(iface, getProcessMap(new HashMap<String, org.apache.thrift.ProcessFunction<I, ? extends org.apache.thrift.TBase>>()));
     }

--- a/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ITZipkinSpanCollector.java
+++ b/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ITZipkinSpanCollector.java
@@ -4,11 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.apache.thrift.transport.TTransportException;
 import org.junit.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.twitter.zipkin.gen.Span;
 
@@ -19,7 +18,7 @@ import com.twitter.zipkin.gen.Span;
  */
 public class ITZipkinSpanCollector {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ITZipkinSpanCollector.class);
+    private static final Logger LOGGER = Logger.getLogger(ITZipkinSpanCollector.class.getName());
     private static final int QUEUE_SIZE = 5;
     private static final int FIRST_BURST_OF_SPANS = 100;
     private static final int SECOND_BURST_OF_SPANS = 20;
@@ -59,7 +58,7 @@ public class ITZipkinSpanCollector {
      * <li>a full queue at which client will be blocked.</li>
      * <li>a wait time of longer than 5 seconds which means SpanProcessingThread will run into timeout.
      * </ol>
-     * 
+     *
      * @throws TTransportException
      * @throws InterruptedException
      */
@@ -106,7 +105,7 @@ public class ITZipkinSpanCollector {
      * end up in collector server.</li>
      * <li>it also shows that stopping ZipkinSpanCollector before all queued spans have been submitted works.</li>
      * </ol>
-     * 
+     *
      * @throws TTransportException
      * @throws InterruptedException
      */

--- a/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ZipkinCollectorReceiver.java
+++ b/brave-zipkin-spancollector/src/test/java/com/github/kristofa/brave/zipkin/ZipkinCollectorReceiver.java
@@ -4,14 +4,14 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TIOStreamTransport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.twitter.zipkin.gen.LogEntry;
 import com.twitter.zipkin.gen.ResultCode;
@@ -21,7 +21,7 @@ import com.twitter.zipkin.gen.ZipkinCollector.Iface;
 
 class ZipkinCollectorReceiver implements Iface {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ZipkinCollectorReceiver.class);
+    private static final Logger LOGGER = Logger.getLogger(ZipkinCollectorReceiver.class.getName());
     private final List<Span> spans = new ArrayList<Span>();
     private final int delayMs;
 
@@ -52,12 +52,12 @@ class ZipkinCollectorReceiver implements Iface {
                 try {
                     Thread.sleep(delayMs);
                 } catch (final InterruptedException e) {
-                    LOGGER.error("Interrupted.", e);
+                    LOGGER.log(Level.SEVERE, "Interrupted.", e);
                 }
             }
 
         } catch (final TException e) {
-            LOGGER.error("TException when getting result.", e);
+            LOGGER.log(Level.SEVERE, "TException when getting result.", e);
             return ResultCode.TRY_LATER;
         }
         return ResultCode.OK;

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>4.1.6.RELEASE</spring.version>
+    <log4j.version>2.3</log4j.version>
+    <httpcomponents.version>4.4.1</httpcomponents.version>
   </properties>
 
   <modules>
@@ -61,16 +63,39 @@
 
   <dependencyManagement>
   	<dependencies>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
   		<dependency>
-    			<groupId>org.springframework</groupId>
+            <groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
 			<version>${spring.version}</version>
-	    	</dependency>
-    		<dependency>
+        </dependency>
+        <dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-context</artifactId>
 			<version>${spring.version}</version>
-	    	</dependency>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
@@ -82,12 +107,6 @@
             <version>${spring.version}</version>
         </dependency>
         <dependency>
-            <!-- For @javax.annotation.Nullable -->
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value</artifactId>
             <version>1.1</version>
@@ -97,11 +116,31 @@
             <artifactId>commons-lang3</artifactId>
             <version>3.4</version>
         </dependency>
-		<dependency>
-		        <groupId>org.apache.httpcomponents</groupId>
-		        <artifactId>httpcore</artifactId>
-		        <version>4.3.2</version>
-    		</dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcomponents.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpcomponents.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-jul</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
   	</dependencies>
   </dependencyManagement>
 
@@ -112,36 +151,23 @@
       <version>4.10</version>
       <scope>test</scope>
     </dependency>
+    <!-- Main code uses jul and tests log with log4j -->
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jul</artifactId>
+        <scope>test</scope>
+    </dependency>
     <dependency>
 		<groupId>org.mockito</groupId>
 		<artifactId>mockito-all</artifactId>
 		<version>1.10.19</version>
 		<scope>test</scope>
 	</dependency>
-	<dependency>
-		<groupId>log4j</groupId>
-		<artifactId>log4j</artifactId>
-		<version>1.2.16</version>
-		<scope>provided</scope>
-	</dependency>
-	<!-- Slf4j is tricky to get right so put our dependencies here. -->
-	<dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.5</version>
-		<scope>provided</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
-    </dependency>
-    <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>1.7.5</version>
-		<scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>
@@ -223,6 +249,15 @@
                             <artifactId>java17</artifactId>
                             <version>1.0</version>
                         </signature>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.18.1</version>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
             	<plugin>


### PR DESCRIPTION
This reworks code and dependencies such that brave-core has a single
dependency on apache-thrift. This decouples us from changes in thrift
and also allows us to consider alternate thrift or otherwise codecs,
such as json or protobuf.

The key changes are local copies of validation code, and a switch from
slf4j to jul. Eventhough slf4j is used when you are using thrift
runtimes, it isn't used in codec. In other words brave-core works
without slf4j.

This also removes the jsr305 dep by using our own Nullable and switching
from PreDestroy to Closable (which are equivalent in Spring Framework).

Finally, this corrects the httpcomponents dependency setup such that it
properly masks and couples to brave-http.