### PR TITLE
Fix NPE with MySQL when EndPoint not submitted yet

### DIFF
--- a/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptor.java
+++ b/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptor.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.mysql;
 
 import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.EndpointSubmitter;
 import com.mysql.jdbc.Connection;
 import com.mysql.jdbc.PreparedStatement;
 import com.mysql.jdbc.ResultSetInternalMethods;
@@ -26,16 +27,21 @@ public class MySQLStatementInterceptor implements StatementInterceptorV2 {
 
     // TODO: is static scope best? ex. preferred to thread local etc?
     static volatile ClientTracer clientTracer;
+    static volatile EndpointSubmitter endpointSubmitter;
 
     public static void setClientTracer(final ClientTracer tracer) {
         clientTracer = tracer;
     }
 
+    public static void setEndpointSubmitter(final EndpointSubmitter submitter) {
+        endpointSubmitter = submitter;
+    }
+
     @Override
     public ResultSetInternalMethods preProcess(final String sql, final Statement interceptedStatement, final Connection connection) throws SQLException {
 
-        ClientTracer clientTracer = this.clientTracer;
-        if (clientTracer != null) {
+        ClientTracer clientTracer = MySQLStatementInterceptor.clientTracer;
+        if (clientTracer != null && endPointSubmitted()) {
             final String sqlToLog;
             // When running a prepared statement, sql will be null and we must fetch the sql from the statement itself
             if (interceptedStatement instanceof PreparedStatement) {
@@ -55,12 +61,21 @@ public class MySQLStatementInterceptor implements StatementInterceptorV2 {
                                                 final Connection connection, final int warningCount, final boolean noIndexUsed, final boolean noGoodIndexUsed,
                                                 final SQLException statementException) throws SQLException {
 
-        ClientTracer clientTracer = this.clientTracer;
-        if (clientTracer != null) {
+        ClientTracer clientTracer = MySQLStatementInterceptor.clientTracer;
+        if (clientTracer != null && endPointSubmitted()) {
             endTrace(clientTracer, warningCount, statementException);
         }
 
         return null;
+    }
+
+    /**
+     * It is possible that this interceptor can be called before any HTTP requests have been served which means information about the end point, which
+     * is used when submitting a client trace, will be missing.
+     * @return True if the end point information is present and so is safe to proceed with the tracing.
+     */
+    private boolean endPointSubmitted() {
+        return endpointSubmitter != null && endpointSubmitter.endpointSubmitted();
     }
 
     private void beginTrace(final ClientTracer tracer, final String sql, final Connection connection) throws SQLException {

--- a/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBean.java
+++ b/brave-mysql/src/main/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBean.java
@@ -1,6 +1,7 @@
 package com.github.kristofa.brave.mysql;
 
 import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.EndpointSubmitter;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -10,12 +11,14 @@ import java.io.IOException;
  */
 public class MySQLStatementInterceptorManagementBean implements Closeable {
 
-    public MySQLStatementInterceptorManagementBean(final ClientTracer tracer) {
+    public MySQLStatementInterceptorManagementBean(final ClientTracer tracer, final EndpointSubmitter submitter) {
         MySQLStatementInterceptor.setClientTracer(tracer);
+        MySQLStatementInterceptor.setEndpointSubmitter(submitter);
     }
 
     @Override
     public void close() throws IOException {
         MySQLStatementInterceptor.setClientTracer(null);
+        MySQLStatementInterceptor.setEndpointSubmitter(null);
     }
 }

--- a/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBeanTest.java
+++ b/brave-mysql/src/test/java/com/github/kristofa/brave/mysql/MySQLStatementInterceptorManagementBeanTest.java
@@ -1,8 +1,8 @@
 package com.github.kristofa.brave.mysql;
 
 import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.EndpointSubmitter;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -13,34 +13,33 @@ import static org.mockito.Mockito.mock;
 
 public class MySQLStatementInterceptorManagementBeanTest {
 
-    private ClientTracer clientTracer;
-
-    @Before
-    public void setup() {
-        clientTracer = mock(ClientTracer.class);
-    }
+    private final ClientTracer clientTracer = mock(ClientTracer.class);
+    private final EndpointSubmitter endpointSubmitter = mock(EndpointSubmitter.class);
 
     @After
     public void clearStatementInterceptor() {
         MySQLStatementInterceptor.setClientTracer(null);
+        MySQLStatementInterceptor.setEndpointSubmitter(null);
     }
 
     @Test
     public void afterPropertiesSetShouldSetTracerOnStatementInterceptor() {
-        new MySQLStatementInterceptorManagementBean(clientTracer);
+        new MySQLStatementInterceptorManagementBean(clientTracer, endpointSubmitter);
         assertSame(clientTracer, MySQLStatementInterceptor.clientTracer);
+        assertSame(endpointSubmitter, MySQLStatementInterceptor.endpointSubmitter);
     }
 
     @Test
     public void closeShouldCleanUpStatementInterceptor() throws IOException {
 
-        final MySQLStatementInterceptorManagementBean subject = new MySQLStatementInterceptorManagementBean(clientTracer);
+        final MySQLStatementInterceptorManagementBean subject = new MySQLStatementInterceptorManagementBean(clientTracer, endpointSubmitter);
 
         MySQLStatementInterceptor.setClientTracer(clientTracer);
 
         subject.close();
 
         assertNull(MySQLStatementInterceptor.clientTracer);
+        assertNull(MySQLStatementInterceptor.endpointSubmitter);
     }
 
 }


### PR DESCRIPTION
If the endpoint hasn't been submitted yet, then you cannot reliably trace client requests (e.g. submitBinaryAnnotation relies on the EndPoint being present)